### PR TITLE
fix typos: ctype_xdigit

### DIFF
--- a/reference/ctype/functions/ctype-xdigit.xml
+++ b/reference/ctype/functions/ctype-xdigit.xml
@@ -40,7 +40,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   如果 <parameter>text</parameter> 里面的每个字符都是十六进制字符。也就是只能包含十进制的树枝和 <literal>[A-Fa-f]</literal> 的字母。否则，返回 &false; 。
+   如果 <parameter>text</parameter> 里面的每个字符都是十六进制字符，也就是只能包含十进制的数值和 <literal>[A-Fa-f]</literal> 的字母，则返回 &true; 。否则返回 &false; 。
   </para>
  </refsect1>
 


### PR DESCRIPTION
修改错别字：`树枝` -> `数值`
页面：https://www.php.net/manual/zh/function.ctype-xdigit.php