### PR TITLE
Fix typo in warn.escapeshell

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -170,14 +170,14 @@ linkend="book.outcontrol">输出控制函数</link>来捕获当前函数的输�
 
 <!-- Warnings -->
 
-<!ENTITY warn.escapeshell '<warning xmlns="http://docbook.org/ns/docbook"><para>当用户提供的数据传入此函数，使用
+<!ENTITY warn.escapeshell '<warning xmlns="http://docbook.org/ns/docbook"><para>当传入用户提供的数据到本函数时，应使用
 <function>escapeshellarg</function> 或 <function>escapeshellcmd</function>
-来确保用户欺骗系统从而执行任意命令。</para></warning>'>
+来防止用户欺骗系统执行任意命令。</para></warning>'>
 
 
 
-<!ENTITY warn.experimental '<warning xmlns="http://docbook.org/ns/docbook"><simpara>此扩展是<emphasis>实验性 </emphasis>的。
-此扩展的表象，包括其函数名称以及其他此扩展的相关文档都可能在未来的 PHP 发布版本中未通知就被修改。使用本扩展风险自担。</simpara></warning>'>
+<!ENTITY warn.experimental '<warning xmlns="http://docbook.org/ns/docbook"><simpara>此扩展是<emphasis>实验性</emphasis>的。此扩展的表象，包括其函数名称以及其他此扩展的相关文档都可能在未来的
+PHP 发布版本中未通知就被修改。使用本扩展风险自担。</simpara></warning>'>
 
 
 

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -176,8 +176,9 @@ linkend="book.outcontrol">输出控制函数</link>来捕获当前函数的输�
 
 
 
-<!ENTITY warn.experimental '<warning xmlns="http://docbook.org/ns/docbook"><simpara>此扩展是<emphasis>实验性</emphasis>的。此扩展的表象，包括其函数名称以及其他此扩展的相关文档都可能在未来的
-PHP 发布版本中未通知就被修改。使用本扩展风险自担。</simpara></warning>'>
+<!ENTITY warn.experimental '<warning xmlns="http://docbook.org/ns/docbook"><simpara>此扩展是<emphasis>实验性</emphasis>的。
+此扩展的行为，包括其函数的名称和围绕此扩展的相关文档都可能在未来的
+PHP 版本中可能会发生变化而不另行通知。使用本扩展应自行承担风险。</simpara></warning>'>
 
 
 

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -177,8 +177,8 @@ linkend="book.outcontrol">输出控制函数</link>来捕获当前函数的输�
 
 
 <!ENTITY warn.experimental '<warning xmlns="http://docbook.org/ns/docbook"><simpara>此扩展是<emphasis>实验性</emphasis>的。
-此扩展的行为，包括其函数的名称和围绕此扩展的相关文档都可能在未来的
-PHP 版本中可能会发生变化而不另行通知。使用本扩展应自行承担风险。</simpara></warning>'>
+此扩展的行为，包括其函数的名称和围绕此扩展的相关文档都可能会在未来的
+PHP 版本中发生变化而不另行通知。使用本扩展应自行承担风险。</simpara></warning>'>
 
 
 


### PR DESCRIPTION
https://www.php.net/manual/en/function.exec.php 的原文有一个 `not` 中文没有翻译到。

> When allowing user-supplied data to be passed to this function, use escapeshellarg() or escapeshellcmd() to ensure that users cannot trick the system into executing arbitrary commands.

本 PR 参照[其它现有 PR](https://github.com/php/doc-zh/pull/99)，只修改 typo 不修改变量信息。此外参照 https://github.com/php/doc-zh/blob/master/README.md#%E6%9C%89%E5%85%B3%E5%9C%A8%E7%BF%BB%E8%AF%91%E5%90%8E%E7%9A%84%E4%B8%AD%E6%96%87%E6%96%87%E4%BB%B6%E4%B8%AD%E7%9A%84%E7%A9%BA%E6%A0%BC%E4%B8%8E%E6%8D%A2%E8%A1%8C%E7%9A%84%E8%AF%B4%E6%98%8E 更新了下面一行。

Co-authored-by: @everything411