### PR TITLE
update constants.xml

### DIFF
--- a/reference/sockets/constants.xml
+++ b/reference/sockets/constants.xml
@@ -347,7 +347,7 @@
    </term>
    <listitem>
     <simpara>
-     用于禁用 TCP Nagle 算法。
+     用于禁用 Nagle TCP 算法。
     </simpara>
    </listitem>
   </varlistentry>
@@ -475,7 +475,7 @@
  </variablelist>
 
  <simpara>
-  以下常量在Windows和类UNIX平台上被定义。每个常量只有在平台上有该常量值的时候才会被定义。
+  以下常量在 Windows 和类 UNIX 平台上被定义。每个常量只有在平台上有该常量值的时候才会被定义。
  </simpara>
 
  <variablelist>
@@ -497,7 +497,7 @@
    </term>
    <listitem>
     <simpara>
-     坏文件编号。
+     错误的文件编号。
     </simpara>
    </listitem>
   </varlistentry>
@@ -618,7 +618,7 @@
    </term>
    <listitem>
     <simpara>
-     非socket套接字操作。
+     对非套接字进行套接字操作。
     </simpara>
    </listitem>
   </varlistentry>
@@ -629,7 +629,7 @@
    </term>
    <listitem>
     <simpara>
-     需要目的地址。
+     需要目标地址。
     </simpara>
    </listitem>
   </varlistentry>
@@ -651,7 +651,7 @@
    </term>
    <listitem>
     <simpara>
-     socket协议类型错误。
+     socket 协议类型错误。
     </simpara>
    </listitem>
   </varlistentry>
@@ -673,7 +673,7 @@
    </term>
    <listitem>
     <simpara>
-     不支持的socket类型。
+     不支持的 socket 类型。
     </simpara>
    </listitem>
   </varlistentry>
@@ -684,7 +684,7 @@
    </term>
    <listitem>
     <simpara>
-     传输断点不支持的操作。
+     传输端点不支持的操作。
     </simpara>
    </listitem>
   </varlistentry>
@@ -728,7 +728,7 @@
    </term>
    <listitem>
     <simpara>
-     网络出现故障。
+     网络中断。
     </simpara>
    </listitem>
   </varlistentry>
@@ -889,7 +889,7 @@
  </variablelist>
  
  <simpara>
-  以下常量只能在windows中定义。
+  以下常量只能在 windows 中定义。
  </simpara>
 
  <variablelist>
@@ -1092,7 +1092,7 @@
  </variablelist>
 
  <simpara>
-  以下常量仅适用于类UNIX。 每个常量只有在该平台上此值可用时被定义。
+  以下常量仅适用于类 UNIX。每个常量只有在该平台上此值可用时被定义。
  </simpara>
 
  <variablelist>
@@ -1125,7 +1125,7 @@
    </term>
    <listitem>
     <simpara>
-     I/O错误。
+     I/O 错误。
     </simpara>
    </listitem>
   </varlistentry>
@@ -1268,7 +1268,7 @@
    </term>
    <listitem>
     <simpara>
-     不是打字机。
+     在 ioctl 系统调用中指定了无效的 ioctl （IO控制）编号。
     </simpara>
    </listitem>
   </varlistentry>
@@ -1323,7 +1323,7 @@
    </term>
    <listitem>
     <simpara>
-     管道断开。
+     管道断开（非正常关闭套接字）。
     </simpara>
    </listitem>
   </varlistentry>
@@ -1360,7 +1360,7 @@
    </term>
    <listitem>
     <simpara>
-     无需要类型的消息。
+     没有指定的消息类型。
     </simpara>
    </listitem>
   </varlistentry>
@@ -1393,7 +1393,7 @@
    </term>
    <listitem>
     <simpara>
-     2级未同步。
+     2 级未同步。
     </simpara>
    </listitem>
   </varlistentry>
@@ -1404,7 +1404,7 @@
    </term>
    <listitem>
     <simpara>
-     3级停止。
+     3 级停止。
     </simpara>
    </listitem>
   </varlistentry>
@@ -1415,7 +1415,7 @@
    </term>
    <listitem>
     <simpara>
-     3级重置。
+     3 级重置。
     </simpara>
    </listitem>
   </varlistentry>
@@ -1448,7 +1448,7 @@
    </term>
    <listitem>
     <simpara>
-     没有可用的CSI结构。
+     没有可用的 CSI 结构。
     </simpara>
    </listitem>
   </varlistentry>
@@ -1459,7 +1459,7 @@
    </term>
    <listitem>
     <simpara>
-     2级停止。
+     2 级停止。
     </simpara>
    </listitem>
   </varlistentry>
@@ -1614,7 +1614,7 @@
    </term>
    <listitem>
     <simpara>
-     Srmount错误。
+     Srmount 错误。
     </simpara>
    </listitem>
   </varlistentry>
@@ -1794,7 +1794,7 @@
    </term>
    <listitem>
     <simpara>
-     远程I/O错误。
+     远程 I/O 错误。
     </simpara>
    </listitem>
   </varlistentry>
@@ -1816,7 +1816,7 @@
    </term>
    <listitem>
     <simpara>
-     未找到媒体。
+     未找到媒介。
     </simpara>
    </listitem>
   </varlistentry>
@@ -1827,7 +1827,7 @@
    </term>
    <listitem>
     <simpara>
-     错误的媒体类型。
+     错误的媒介类型。
     </simpara>
    </listitem>
   </varlistentry>


### PR DESCRIPTION
`Not a typewriter` 的翻译没有参考原意。这里参考了[维基百科](https://en.wikipedia.org/wiki/Not_a_typewriter)的解释：

> In [computing](https://en.wikipedia.org/wiki/Computing), "Not a [typewriter](https://en.wikipedia.org/wiki/Typewriter)" or ENOTTY[[1]](https://en.wikipedia.org/wiki/Not_a_typewriter#cite_note-1) is an error code defined in the [errno.h](https://en.wikipedia.org/wiki/Errno.h) found on many [Unix](https://en.wikipedia.org/wiki/Unix) systems. This code is now used to indicate that an invalid [ioctl](https://en.wikipedia.org/wiki/Ioctl) (input/output control) number was specified in an ioctl system call.

@sy-records 辛苦大佬给看看这个了。😀