### PR TITLE
统一escape的翻译为转义

### DIFF
--- a/appendices/migration70/incompatible/strings.xml
+++ b/appendices/migration70/incompatible/strings.xml
@@ -71,7 +71,7 @@ var_dump($int); // int(65535)
 
   <para>
    由于新的
-   <link linkend="migration70.new-features.unicode-codepoint-escape-syntax">Unicode codepoint 转译语法</link>语法，
+   <link linkend="migration70.new-features.unicode-codepoint-escape-syntax">Unicode codepoint 转义语法</link>，
    紧连着无效序列并包含<literal>\u{</literal> 的字串可能引起致命错误。 为了避免这一报错，应该避免反斜杠开头。
   </para>
  </sect3>

--- a/reference/exec/functions/escapeshellarg.xml
+++ b/reference/exec/functions/escapeshellarg.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="function.escapeshellarg" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>escapeshellarg</refname>
-  <refpurpose>把字符串转码为可以在 shell 命令里使用的参数</refpurpose>
+  <refpurpose>把字符串转义为可以在 shell 命令里使用的参数</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,7 +15,7 @@
    <methodparam><type>string</type><parameter>arg</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <function>escapeshellarg</function> 将给字符串增加一个单引号并且能引用或者转码任何已经存在的单引号，这样以确保能够直接将一个字符串传入 shell
+   <function>escapeshellarg</function> 将给字符串增加一个单引号并且能引用或者转义任何已经存在的单引号，这样以确保能够直接将一个字符串传入 shell
    函数，并且还是确保安全的。对于用户输入的部分参数就应该使用这个函数。shell 函数包含<function>exec</function>、<function>system</function>
    和<link linkend="language.operators.execution">执行运算符</link> 。
   </para>
@@ -33,7 +33,7 @@
      <term><parameter>arg</parameter></term>
      <listitem>
       <para>
-       需要被转码的参数。
+       需要被转义的参数。
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
`escape`翻译为`转义`现在应该没啥疑问了，这个PR主要是统一一下历史遗留的翻译