### PR TITLE
Remove touch function redundant parameter declaration

### DIFF
--- a/reference/filesystem/functions/touch.xml
+++ b/reference/filesystem/functions/touch.xml
@@ -12,8 +12,6 @@
   <methodsynopsis>
    <type>bool</type><methodname>touch</methodname>
    <methodparam><type>string</type><parameter>filename</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>time</parameter><initializer>time()</initializer></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>atime</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>mtime</parameter><initializer>&null;</initializer></methodparam>
    <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>atime</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>


### PR DESCRIPTION
There are 2 redundant parameters here, which do not correspond to the English documentation.