### PR TITLE
Convert MongoDB from set to book

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 6b53a028fb43eb697c961c81053543fc51bc9028 Maintainer: Gregory Status: ready -->
+<!-- EN-Revision: 3e871fe7eab38f9b0398569c57a1dd0c21e69652 Maintainer: Gregory Status: ready -->
 <!-- CREDITS: dallas, mowangjuanzi, Luffy -->
 <!-- 请保持此文件与英文文件中相应的每个 ENTITY 行号一一对应以便于对照，修改与更新！ -->
 

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -3625,7 +3625,7 @@ local: {
      </para>
      <note>
       <simpara>
-       When evaluating query criteria, MongoDB compares types and values according to its own <link xlink:href="&url.mongodb.docs;reference/bson-type-comparison-order/" xmlns:xlink="http://www.w3.org/1999/xlink">comparison rules for BSON types</link>, which differs from PHP&apos;s <link linkend="types.comparisons">comparison</link> and <link linkend="language.types.type-juggling">type juggling</link> rules. When matching a special BSON type the query criteria should use the respective <link linkend="book.bson">BSON class</link> (e.g. use <classname>MongoDB\BSON\ObjectId</classname> to match an <link xlink:href="&url.mongodb.docs.objectid;" xmlns:xlink="http://www.w3.org/1999/xlink">ObjectId</link>).
+       When evaluating query criteria, MongoDB compares types and values according to its own <link xlink:href="&url.mongodb.docs;reference/bson-type-comparison-order/" xmlns:xlink="http://www.w3.org/1999/xlink">comparison rules for BSON types</link>, which differs from PHP&apos;s <link linkend="types.comparisons">comparison</link> and <link linkend="language.types.type-juggling">type juggling</link> rules. When matching a special BSON type the query criteria should use the respective <link linkend="mongodb.bson">BSON class</link> (e.g. use <classname>MongoDB\BSON\ObjectId</classname> to match an <link xlink:href="&url.mongodb.docs.objectid;" xmlns:xlink="http://www.w3.org/1999/xlink">ObjectId</link>).
       </simpara>
      </note>
     </listitem>

--- a/reference/mongodb/exceptions.xml
+++ b/reference/mongodb/exceptions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4083e8f9523a60390960c52a7ab810dc7b096d40 Maintainer: daijie Status: ready -->
+<!-- EN-Revision: 3e871fe7eab38f9b0398569c57a1dd0c21e69652 Maintainer: daijie Status: ready -->
 <!-- CREDITS: mowangjuanzi, Luffy -->
  <part xml:id="mongodb.exceptions" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <titleabbrev>MongoDB\Driver\Exception</titleabbrev>

--- a/reference/mongodb/exceptions.xml
+++ b/reference/mongodb/exceptions.xml
@@ -2,7 +2,7 @@
 <!-- $Revision$ -->
 <!-- EN-Revision: 4083e8f9523a60390960c52a7ab810dc7b096d40 Maintainer: daijie Status: ready -->
 <!-- CREDITS: mowangjuanzi, Luffy -->
- <book xml:id="mongodb.exceptions" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <part xml:id="mongodb.exceptions" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <titleabbrev>MongoDB\Driver\Exception</titleabbrev>
   <title>Exception 类</title>
 
@@ -67,4 +67,4 @@
    </itemizedlist>
   </article>
 
- </book>
+ </part>

--- a/reference/mongodb/mongodb.xml
+++ b/reference/mongodb/mongodb.xml
@@ -2,7 +2,7 @@
 <!-- $Revision$ -->
 <!-- EN-Revision: dd9038795cefd9b08ce1453b770496cbf132782e Maintainer: daijie Status: ready -->
 <!-- CREDITS: mowangjuanzi, Luffy -->
- <book xml:id="book.mongodb" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <part xml:id="mongodb.mongodb" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <?phpdoc extension-membership="pecl" ?>
   <title>MongoDB 扩展类</title>
   <titleabbrev>MongoDB\Driver</titleabbrev>
@@ -30,5 +30,5 @@
   &reference.mongodb.mongodb.driver.writeconcernerror;
   &reference.mongodb.mongodb.driver.writeerror;
   &reference.mongodb.mongodb.driver.writeresult;
- </book>
+ </part>
 

--- a/reference/mongodb/mongodb.xml
+++ b/reference/mongodb/mongodb.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: dd9038795cefd9b08ce1453b770496cbf132782e Maintainer: daijie Status: ready -->
+<!-- EN-Revision: 3e871fe7eab38f9b0398569c57a1dd0c21e69652 Maintainer: daijie Status: ready -->
 <!-- CREDITS: mowangjuanzi, Luffy -->
  <part xml:id="mongodb.mongodb" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <?phpdoc extension-membership="pecl" ?>


### PR DESCRIPTION
This PR converts `doc-zh`'s MongoDB chapter from a `<set>` to a `<book>` as is done in https://github.com/php/doc-en/pull/3627. This needs the `doc-en` PR and https://github.com/php/doc-base/pull/138 both to work properly.

Also, the revision hashes probably need updating once the `doc-en` changes are merged.