### PR TITLE
fix GD imagestring coordinate incorrect description

### DIFF
--- a/reference/image/functions/imagestring.xml
+++ b/reference/image/functions/imagestring.xml
@@ -32,7 +32,7 @@
      <term><parameter>x</parameter></term>
      <listitem>
       <para>
-       左下角的 x 坐标。
+       左上角的 x 坐标。
       </para>
      </listitem>
     </varlistentry>
@@ -40,7 +40,7 @@
      <term><parameter>y</parameter></term>
      <listitem>
       <para>
-       左下角的 y 坐标。
+       左上角的 y 坐标。
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
xy coordinate _upper left corner_ was incorrectly described as `左下角`