### PR TITLE
Translate missed English text in datetime, filesystem, openssl and session

### DIFF
--- a/reference/datetime/dateerror.xml
+++ b/reference/datetime/dateerror.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: lacatoire Status: ready -->
+<reference xml:id="class.dateerror" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>DateError 类</title>
+ <titleabbrev>DateError</titleabbrev>
+
+ <partintro>
+
+<!-- {{{ DateError intro -->
+  <section xml:id="dateerror.intro">
+   &reftitle.intro;
+   <para>
+    当找不到时区数据库或数据库包含无效数据时抛出。
+   </para>
+   <para>
+    此错误不应该出现，并且与代码无关。有两个子异常（<exceptionname>DateObjectError</exceptionname>
+    和 <exceptionname>DateRangeError</exceptionname>），它们根据程序员错误或范围相关问题抛出。
+   </para>
+  </section>
+<!-- }}} -->
+
+  <section xml:id="dateerror.synopsis">
+   &reftitle.classsynopsis;
+
+<!-- {{{ Synopsis -->
+   <classsynopsis class="class">
+    <ooexception>
+     <exceptionname>DateError</exceptionname>
+    </ooexception>
+
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>Error</classname>
+    </ooclass>
+
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])">
+     <xi:fallback/>
+    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])">
+     <xi:fallback/>
+    </xi:include>
+   </classsynopsis>
+<!-- }}} -->
+
+  </section>
+
+  <section role="seealso">
+   &reftitle.seealso;
+   <simplelist>
+    <member><exceptionname>DateObjectError</exceptionname></member>
+    <member><exceptionname>DateRangeError</exceptionname></member>
+   </simplelist>
+  </section>
+ </partintro>
+
+</reference>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/datetime/dateexception.xml
+++ b/reference/datetime/dateexception.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: lacatoire Status: ready -->
+<reference xml:id="class.dateexception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>DateException 类</title>
+ <titleabbrev>DateException</titleabbrev>
+
+ <partintro>
+
+<!-- {{{ DateException intro -->
+  <section xml:id="dateexception.intro">
+   &reftitle.intro;
+   <para>
+    日期/时间异常的父类，用于由用户输入或需要解析的自由格式文本参数引发的问题。
+   </para>
+   <para>
+    该扩展会抛出以下子异常：
+    <itemizedlist>
+     <listitem><simpara><exceptionname>DateInvalidOperationException</exceptionname></simpara></listitem>
+     <listitem><simpara><exceptionname>DateInvalidTimezoneException</exceptionname></simpara></listitem>
+     <listitem><simpara><exceptionname>DateMalformedIntervalStringException</exceptionname></simpara></listitem>
+     <listitem><simpara><exceptionname>DateMalformedPeriodStringException</exceptionname></simpara></listitem>
+     <listitem><simpara><exceptionname>DateMalformedStringException</exceptionname></simpara></listitem>
+    </itemizedlist>
+   </para>
+  </section>
+<!-- }}} -->
+
+  <section xml:id="dateexception.synopsis">
+   &reftitle.classsynopsis;
+
+<!-- {{{ Synopsis -->
+   <classsynopsis class="class">
+    <ooexception>
+     <exceptionname>DateException</exceptionname>
+    </ooexception>
+
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>Exception</classname>
+    </ooclass>
+
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
+     <xi:fallback/>
+    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
+     <xi:fallback/>
+    </xi:include>
+   </classsynopsis>
+<!-- }}} -->
+
+  </section>
+
+ </partintro>
+
+</reference>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/datetime/datetime/settime.xml
+++ b/reference/datetime/datetime/settime.xml
@@ -99,10 +99,8 @@
     <tbody>
      <row>
       <entry>8.1.0</entry>
-      <entry>The behaviour with double existing hours (during the fall-back
-      DST transition) changed. Previously PHP would pick the second occurrence
-      (after the DST transition), instead of the first occurrence (before DST
-       transition).</entry>
+      <entry>重复存在的小时（在夏令时回拨转换期间）的行为已更改。之前
+      PHP 会选择第二次出现的时间（夏令时转换之后），而不是第一次出现的时间（夏令时转换之前）。</entry>
      </row>
      <row>
       <entry>7.1.0</entry>

--- a/reference/datetime/datetimeinterface.xml
+++ b/reference/datetime/datetimeinterface.xml
@@ -301,7 +301,7 @@
      <term><constant>DATE_RFC3339</constant></term>
      <listitem>
       <simpara>
-       同 <constant>DATE_ATOM</constant>（自 PHP 5.1.3 版本可用）
+       同 <constant>DATE_ATOM</constant>
       </simpara>
      </listitem>
     </varlistentry>
@@ -340,7 +340,7 @@
      <term><constant>DATE_W3C</constant></term>
      <listitem>
       <simpara>
-       RSS 格式（示例：2005-08-15T15:52:01+00:00）
+       World Wide Web Consortium（示例：2005-08-15T15:52:01+00:00）
       </simpara>
      </listitem>
     </varlistentry>

--- a/reference/filesystem/functions/move-uploaded-file.xml
+++ b/reference/filesystem/functions/move-uploaded-file.xml
@@ -70,7 +70,7 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>Uploading multiple files</title>
+    <title>上传多个文件</title>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/openssl/functions/openssl-sign.xml
+++ b/reference/openssl/functions/openssl-sign.xml
@@ -1,0 +1,204 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 9a8c593c09cf7d84085989e42f3b2b23536279db Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.openssl-sign" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>openssl_sign</refname>
+  <refpurpose>生成签名</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>openssl_sign</methodname>
+   <methodparam><type>string</type><parameter>data</parameter></methodparam>
+   <methodparam><type>string</type><parameter role="reference">signature</parameter></methodparam>
+   <methodparam><modifier role="attribute">#[\SensitiveParameter]</modifier><type class="union"><type>OpenSSLAsymmetricKey</type><type>OpenSSLCertificate</type><type>array</type><type>string</type></type><parameter>private_key</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>int</type></type><parameter>algorithm</parameter><initializer><constant>OPENSSL_ALGO_SHA1</constant></initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>padding</parameter><initializer>0</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   <function>openssl_sign</function> 使用与
+   <parameter>private_key</parameter> 关联的私钥为指定的
+   <parameter>data</parameter> 生成加密数字签名。注意数据本身并未被加密。
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>data</parameter></term>
+     <listitem>
+      <para>
+       要签名的数据字符串。
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>signature</parameter></term>
+     <listitem>
+      <para>
+       如果调用成功，签名将返回到 <parameter>signature</parameter> 中。
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>private_key</parameter></term>
+     <listitem>
+      <para>
+       <classname>OpenSSLAsymmetricKey</classname> - 一个密钥，通过 <function>openssl_get_privatekey</function> 函数返回。
+      </para>
+      <para>
+       <type>string</type> - 一个 <acronym>PEM</acronym> 格式的密钥。
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>algorithm</parameter></term>
+     <listitem>
+      <para>
+       <type>int</type> - 以下<link linkend="openssl.signature-algos">签名算法</link>之一。
+      </para>
+      <para>
+       <type>string</type> - 由 <function>openssl_get_md_methods</function> 函数返回的有效字符串，例如 "sha256WithRSAEncryption" 或 "sha384"。
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>padding</parameter></term>
+     <listitem>
+      <simpara>RSA PSS 填充方案。</simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       添加了可选参数 <parameter>padding</parameter>。
+      </entry>
+     </row>
+     <row>
+      <entry>8.0.0</entry>
+      <entry>
+       <parameter>private_key</parameter> 现在接受 <classname>OpenSSLAsymmetricKey</classname>
+       或 <classname>OpenSSLCertificate</classname> 实例；之前接受类型 <literal>OpenSSL key</literal> 或
+       <literal>OpenSSL X.509</literal> 的 &resource;。
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title><function>openssl_sign</function> 示例</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+// $data is assumed to contain the data to be signed
+
+// fetch private key from file and ready it
+$pkeyid = openssl_pkey_get_private("file://src/openssl-0.9.6/demos/sign/key.pem");
+
+// compute signature
+openssl_sign($data, $signature, $pkeyid);
+
+// free the key from memory
+openssl_free_key($pkeyid);
+?>
+]]>
+    </programlisting>
+   </example>
+   <example>
+    <title><function>openssl_sign</function> 示例</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+//data you want to sign
+$data = 'my data';
+
+//create new private and public key
+$new_key_pair = openssl_pkey_new(array(
+    "private_key_bits" => 2048,
+    "private_key_type" => OPENSSL_KEYTYPE_RSA,
+));
+openssl_pkey_export($new_key_pair, $private_key_pem);
+
+$details = openssl_pkey_get_details($new_key_pair);
+$public_key_pem = $details['key'];
+
+//create signature
+openssl_sign($data, $signature, $private_key_pem, OPENSSL_ALGO_SHA256);
+
+//save for later
+file_put_contents('private_key.pem', $private_key_pem);
+file_put_contents('public_key.pem', $public_key_pem);
+file_put_contents('signature.dat', $signature);
+
+//verify signature
+$r = openssl_verify($data, $signature, $public_key_pem, "sha256WithRSAEncryption");
+var_dump($r);
+?>
+]]>
+    </programlisting>
+   </example>
+
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>openssl_verify</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/session/functions/session-abort.xml
+++ b/reference/session/functions/session-abort.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 35b95a56ccc03b66af7117fc815ac7881e2e0ad3 Maintainer: lacatoire Status: ready -->
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.session-abort">
+ <refnamediv>
+  <refname>session_abort</refname>
+  <refpurpose>丢弃会话数组的更改并结束会话</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>session_abort</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   <function>session_abort</function> 在不保存数据的情况下结束会话。
+   因此会话数据中的原始值会被保留。
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>7.2.0</entry>
+      <entry>
+       此函数的返回类型现在是 <type>bool</type>。
+       之前是 <type>void</type>。
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><varname>$_SESSION</varname></member>
+    <member>
+     <link linkend="ini.session.auto-start">session.auto_start</link>
+     配置指示
+    </member>
+    <member><function>session_start</function></member>
+    <member><function>session_reset</function></member>
+    <member><function>session_commit</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/session/functions/session-gc.xml
+++ b/reference/session/functions/session-gc.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 372350f3bfad45ba01db850a1a3be40c803e196b Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.session-gc" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>session_gc</refname>
+  <refpurpose>执行会话数据垃圾回收</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type class="union"><type>int</type><type>false</type></type><methodname>session_gc</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   默认情况下，PHP 使用 <link linkend="ini.session.gc-probability">session.gc_probability</link>
+   在每次请求时以概率方式运行会话垃圾回收器。这种方法存在一些局限性：
+  </simpara>
+  <simplelist>
+   <member>低流量站点的会话数据可能无法在预期时间内被删除。</member>
+   <member>高流量站点的垃圾回收器可能运行过于频繁，执行不必要的额外工作。</member>
+   <member>垃圾回收在用户请求时执行，用户可能会感受到延迟。</member>
+  </simplelist>
+  <simpara>
+   对于生产系统，建议通过将
+   <link linkend="ini.session.gc-probability">session.gc_probability</link> 设置为 <literal>0</literal>
+   来禁用基于概率的垃圾回收，并定期显式触发垃圾回收器，例如在类 UNIX 系统上使用
+   "cron" 运行调用 <function>session_gc</function> 的脚本。
+  </simpara>
+
+  <note>
+   <simpara>
+    从命令行 PHP 脚本调用 <function>session_gc</function> 时，
+    <link linkend="ini.session.save-path">session.save_path</link> 必须设置为与
+    Web 请求相同的值，并且脚本必须对会话文件具有访问和删除权限。这可能受到脚本运行用户的影响，
+    以及容器或沙箱功能（如 systemd 的 <literal>PrivateTmp=</literal> 选项）的影响。
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   <function>session_gc</function> 成功时返回删除的会话条目数，&return.falseforfailure;。
+  </simpara>
+  <note>
+   <simpara>
+    旧的会话保存处理程序不返回删除的会话条目数，而只返回成功/失败标志。在这种情况下，
+    无论实际删除了多少会话条目，都会返回 <literal>1</literal>。
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>用于 cron 等任务管理器的 <function>session_gc</function> 示例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+// Note: This script should be executed by the same user of web server process.
+
+// Need active session to initialize session data storage access.
+session_start();
+
+// Executes GC immediately
+session_gc();
+
+// Clean up session ID created by session_start()
+session_destroy();
+?>
+]]>
+   </programlisting>
+  </example>
+  <example>
+   <title>用于用户可访问脚本的 <function>session_gc</function> 示例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+// Note: session_gc() is recommended to be used by a task manager script, but
+// it may be used as follows.
+
+// Used for last GC time check
+$gc_time = '/tmp/php_session_last_gc';
+$gc_period = 1800;
+
+session_start();
+// Execute GC only when GC period elapsed.
+// i.e. Calling session_gc() every request is waste of resources.
+if (file_exists($gc_time)) {
+    if (filemtime($gc_time) < time() - $gc_period) {
+        session_gc();
+        touch($gc_time);
+    }
+} else {
+    touch($gc_time);
+}
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>session_start</function></member>
+   <member><function>session_destroy</function></member>
+   <member><link linkend="ini.session.gc-probability">session.gc_probability</link></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/session/functions/session-regenerate-id.xml
+++ b/reference/session/functions/session-regenerate-id.xml
@@ -71,7 +71,7 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>A <function>session_regenerate_id</function> 示例</title>
+    <title><function>session_regenerate_id</function> 示例</title>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -119,7 +119,7 @@ print_r($_SESSION);
   
   <para>
    <example>
-    <title>Avoiding lost session by <function>session_regenerate_id</function></title>
+    <title>通过 <function>session_regenerate_id</function> 避免会话丢失</title>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/session/functions/session-reset.xml
+++ b/reference/session/functions/session-reset.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 35b95a56ccc03b66af7117fc815ac7881e2e0ad3 Maintainer: lacatoire Status: ready -->
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.session-reset">
+ <refnamediv>
+  <refname>session_reset</refname>
+  <refpurpose>使用会话存储中的原始值重新初始化会话数组</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>session_reset</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   <function>session_reset</function> 使用会话存储中保存的原始值重新初始化会话。
+   此函数需要一个活跃的会话，并且会丢弃 $_SESSION 中的所有更改。
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>7.2.0</entry>
+      <entry>
+       此函数的返回类型现在是 <type>bool</type>。
+       之前返回类型是 <type>void</type>。
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><varname>$_SESSION</varname></member>
+    <member>
+     <link linkend="ini.session.auto-start">session.auto_start</link>
+     配置指示
+    </member>
+    <member><function>session_start</function></member>
+    <member><function>session_abort</function></member>
+    <member><function>session_commit</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Translate remaining English text in existing files:
- `datetime/datetimeinterface.xml`: fix W3C constant description, remove extra version note on RFC3339
- `datetime/datetime/settime.xml`: translate DST transition changelog entry (8.1.0)
- `filesystem/functions/move-uploaded-file.xml`: translate example title
- `session/functions/session-regenerate-id.xml`: translate example titles

Add missing translated files:
- `datetime/dateerror.xml`
- `datetime/dateexception.xml`
- `openssl/functions/openssl-sign.xml`
- `session/functions/session-abort.xml`
- `session/functions/session-gc.xml`
- `session/functions/session-reset.xml`