### PR TITLE
翻译 appendices/migration56/openssl.xml

### DIFF
--- a/appendices/examples.xml
+++ b/appendices/examples.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: Singi Status: ready -->
+<appendix xml:id="examples" xmlns="http://docbook.org/ns/docbook">
+ <title>关于手册示例</title>
+ <simpara>
+  需要注意的是，为了清晰简洁，PHP 文档中的许多示例都省略了错误和异常处理。
+ </simpara>
+ <simpara>
+  这并不意味着生产环境代码可以省略错误处理，因为此举可能会引发 <exceptionname>TypeError</exceptionname> 错误、强制转换失败值（例如将布尔值 &false; 转为空字符串），或是违背代码预设逻辑，进而产生难以排查的隐蔽漏洞。部分扩展库提供了完整示例，其中均包含错误处理逻辑，用以演示该扩展所提供各类函数与方法的规范用法。
+ </simpara>
+</appendix>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/appendices/migration56/openssl.xml
+++ b/appendices/migration56/openssl.xml
@@ -1,0 +1,434 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: Singi Status: ready -->
+<!-- $Revision$ -->
+
+<sect1 xml:id="migration56.openssl" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <title>PHP 5.6.x 中的 OpenSSL 更改</title>
+
+ <sect2 xml:id="migration56.openssl.peer-verification">
+  <title>在使用 SSL/TLS 时，流包装器现在默认验证对等证书和主机名</title>
+
+  &migration56.openssl.peer-verification;
+ </sect2>
+
+ <sect2 xml:id="migration56.openssl.fingerprint">
+  <title>证书指纹</title>
+
+  <para>
+   已添加对提取和验证证书指纹的支持。添加了 <function>openssl_x509_fingerprint</function>
+   以从 X.509 证书中提取指纹，并且添加了两个
+   <link linkend="context.ssl">SSL 流上下文</link> 选项：<literal>capture_peer_cert</literal> 用于捕获对等方的 X.509
+   证书，以及 <literal>peer_fingerprint</literal> 用于断言对等方的证书应与给定的指纹匹配。
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration56.openssl.ciphers">
+  <title>默认密码套件已更新</title>
+
+  <para>
+   PHP 使用的默认密码套件已更新为基于
+   <link xlink:href="&url.openssl.ciphers.mozilla;">Mozilla 密码套件推荐</link> 的更安全的列表，
+   另外排除了两个：匿名 Diffie-Hellman 密码套件和 RC4。
+  </para>
+
+  <para>
+   此列表可以通过新的
+   <constant>OPENSSL_DEFAULT_STREAM_CIPHERS</constant> 常量访问，并且可以通过设置
+   <link linkend="context.ssl.ciphers"><parameter>ciphers</parameter></link>
+   上下文选项来覆盖。
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration56.openssl.tls-compression">
+  <title>默认禁用压缩</title>
+
+  <para>
+   SSL/TLS 压缩已默认禁用以缓解 CRIME
+   攻击。PHP 5.4.13 添加了
+   <link linkend="context.ssl.disable-compression"><parameter>disable_compression</parameter></link>
+   上下文选项以允许禁用压缩：现在默认设置为
+   &true;（即，压缩被禁用）。
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration56.openssl.honor-cipher-order">
+  <title>允许服务器优先选择其密码套件顺序</title>
+
+  <para>
+   已添加 <parameter>honor_cipher_order</parameter> SSL 上下文选项，以允许加密流服务器通过优先使用服务器的密码套件而不是客户端的密码套件来减轻 BEAST 漏洞。
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration56.openssl.metadata">
+  <title>访问协商的协议和密码套件</title>
+
+  <para>
+   现在可以通过 <function>stream_get_meta_data</function> 或
+   <function>stream_context_get_options</function> 访问为加密流协商的协议和密码套件，当
+   <parameter>capture_session_meta</parameter> SSL 上下文选项设置为
+   &true; 时。
+  </para>
+
+  <informalexample>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$ctx = stream_context_create(['ssl' => [
+    'capture_session_meta' => TRUE
+]]);
+ 
+$html = file_get_contents('https://google.com/', FALSE, $ctx);
+$meta = stream_context_get_options($ctx)['ssl']['session_meta'];
+var_dump($meta);
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+array(4) {
+  ["protocol"]=>
+  string(5) "TLSv1"
+  ["cipher_name"]=>
+  string(20) "ECDHE-RSA-AES128-SHA"
+  ["cipher_bits"]=>
+  int(128)
+  ["cipher_version"]=>
+  string(11) "TLSv1/SSLv3"
+}
+]]>
+   </screen>
+  </informalexample>
+ </sect2>
+
+ <sect2 xml:id="migration56.openssl.forward-secrecy">
+  <title>加密流服务器中完美前向保密的新选项</title>
+
+  <para>
+   加密客户端流已经支持完美前向保密，因为它通常由服务器控制。使用能够进行完美前向保密的证书的 PHP 加密服务器流不需要采取任何额外操作来启用 PFS；但是，已添加了许多新的 SSL 上下文选项，以允许对 PFS 进行更多控制并处理可能出现的任何兼容性问题。
+  </para>
+
+  <variablelist>
+   <varlistentry>
+    <term><parameter>ecdh_curve</parameter></term>
+    <listitem>
+     <para>
+      此选项允许选择用于 ECDH 密码套件的特定曲线。如果未指定，将使用 <literal>prime256v1</literal>。
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>dh_param</parameter></term>
+    <listitem>
+     <para>
+      指向包含 Diffie-Hellman 密钥交换参数的文件路径，例如由以下命令创建的文件：
+     </para>
+     <programlisting role="shell">
+<![CDATA[
+openssl dhparam -out /path/to/my/certs/dh-2048.pem 2048
+]]>
+     </programlisting>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>single_dh_use</parameter></term>
+    <listitem>
+     <para>
+      如果设置为 &true;，在使用 Diffie-Hellman 参数时将创建一个新的密钥对，从而改善前向保密。
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>single_ecdh_use</parameter></term>
+    <listitem>
+     <para>
+      如果设置为 &true;，当协商 ECDH 密码套件时将始终生成新的密钥对。这改善了前向保密。
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </sect2>
+
+ <sect2 xml:id="migration56.openssl.crypto-method">
+  <title>SSL/TLS 版本选择</title>
+
+  <para>
+   现在可以通过 <parameter>crypto_method</parameter> SSL 上下文选项或通过在创建流包装器时指定特定传输来选择 SSL/TLS 版本（例如，通过调用
+   <function>stream_socket_client</function> 或
+   <function>stream_socket_server</function>）。
+  </para>
+
+  <para>
+   <parameter>crypto_method</parameter> SSL 上下文选项接受一个位掩码，枚举允许的协议，<function>stream_socket_enable_crypto</function> 的
+   <parameter>crypto_type</parameter> 也是如此。
+   <!-- TODO: link to full list, which is too big for this page but should be
+              in the crypto_method and stream_socket_enable_crypto()
+              documentation. -->
+  </para>
+
+  <segmentedlist>
+   <title>选定的协议版本及其对应选项</title>
+   <segtitle>协议</segtitle>
+   <segtitle>客户端标志</segtitle>
+   <segtitle>服务器标志</segtitle>
+   <segtitle>传输</segtitle>
+   <seglistitem>
+    <seg>任何 TLS 或 SSL 版本</seg>
+    <seg><constant>STREAM_CRYPTO_METHOD_ANY_CLIENT</constant></seg>
+    <seg><constant>STREAM_CRYPTO_METHOD_ANY_SERVER</constant></seg>
+    <seg><literal>ssl://</literal></seg>
+   </seglistitem>
+   <seglistitem>
+    <seg>任何 TLS 版本</seg>
+    <seg><constant>STREAM_CRYPTO_METHOD_TLS_CLIENT</constant></seg>
+    <seg><constant>STREAM_CRYPTO_METHOD_TLS_SERVER</constant></seg>
+    <seg><literal>tls://</literal></seg>
+   </seglistitem>
+   <seglistitem>
+    <seg>TLS 1.0</seg>
+    <seg><constant>STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT</constant></seg>
+    <seg><constant>STREAM_CRYPTO_METHOD_TLSv1_0_SERVER</constant></seg>
+    <seg><literal>tlsv1.0://</literal></seg>
+   </seglistitem>
+   <seglistitem>
+    <seg>TLS 1.1</seg>
+    <seg><constant>STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT</constant></seg>
+    <seg><constant>STREAM_CRYPTO_METHOD_TLSv1_1_SERVER</constant></seg>
+    <seg><literal>tlsv1.1://</literal></seg>
+   </seglistitem>
+   <seglistitem>
+    <seg>TLS 1.2</seg>
+    <seg><constant>STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT</constant></seg>
+    <seg><constant>STREAM_CRYPTO_METHOD_TLSv1_2_SERVER</constant></seg>
+    <seg><literal>tlsv1.2://</literal></seg>
+   </seglistitem>
+   <seglistitem>
+    <seg>SSL 3</seg>
+    <seg><constant>STREAM_CRYPTO_METHOD_SSLv3_CLIENT</constant></seg>
+    <seg><constant>STREAM_CRYPTO_METHOD_SSLv3_SERVER</constant></seg>
+    <seg><literal>sslv3://</literal></seg>
+   </seglistitem>
+  </segmentedlist>
+
+  <informalexample>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+// Requiring TLS 1.0 or better when using file_get_contents():
+$ctx = stream_context_create([
+    'ssl' => [
+        'crypto_method' => STREAM_CRYPTO_METHOD_TLS_CLIENT,
+    ],
+]);
+$html = file_get_contents('https://google.com/', false, $ctx);
+
+// Requiring TLS 1.1 or 1.2:
+$ctx = stream_context_create([
+    'ssl' => [
+        'crypto_method' => STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT |
+                           STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT,
+    ],
+]);
+$html = file_get_contents('https://google.com/', false, $ctx);
+
+// Connecting using the tlsv1.2:// stream socket transport.
+$sock = stream_socket_client('tlsv1.2://google.com:443/');
+
+?>
+]]>
+   </programlisting>
+  </informalexample>
+ </sect2>
+
+ <sect2 xml:id="migration56.openssl.default-certificate-paths">
+  <title>添加了 <function>openssl_get_cert_locations</function></title>
+
+  <para>
+   已添加 <function>openssl_get_cert_locations</function> 函数：它返回 PHP 在查找 CA 包时将搜索的默认位置。
+  </para>
+
+  <informalexample>
+   <programlisting role="php">
+<![CDATA[
+<?php
+var_dump(openssl_get_cert_locations());
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+array(8) {
+  ["default_cert_file"]=>
+  string(21) "/etc/pki/tls/cert.pem"
+  ["default_cert_file_env"]=>
+  string(13) "SSL_CERT_FILE"
+  ["default_cert_dir"]=>
+  string(18) "/etc/pki/tls/certs"
+  ["default_cert_dir_env"]=>
+  string(12) "SSL_CERT_DIR"
+  ["default_private_dir"]=>
+  string(20) "/etc/pki/tls/private"
+  ["default_default_cert_area"]=>
+  string(12) "/etc/pki/tls"
+  ["ini_cafile"]=>
+  string(0) ""
+  ["ini_capath"]=>
+  string(0) ""
+}
+]]>
+   </screen>
+  </informalexample>
+ </sect2>
+
+ <sect2 xml:id="migration56.openssl.spki">
+  <title>SPKI 支持</title>
+
+  <para>
+   已添加对生成、提取和验证签名公钥和挑战（SPKAC）的支持。添加了 <function>openssl_spki_new</function>、
+   <function>openssl_spki_verify</function>、
+   <function>openssl_spki_export_challenge</function> 和
+   <function>openssl_spki_export</function> 以从 <literal>KeyGen</literal> HTML5 元素生成的 SPKAC 创建、验证和导出 <acronym>PEM</acronym> 公钥以及关联的挑战。
+  </para>
+
+  <variablelist>
+   <varlistentry>
+    <term><parameter>openssl_spki_new</parameter></term>
+    <listitem>
+     <para>
+      使用私钥、挑战字符串和哈希算法生成新的 SPKAC。
+     </para>
+
+     <informalexample>
+      <programlisting role="php">
+<![CDATA[
+<?php
+$pkey = openssl_pkey_new();
+openssl_pkey_export($pkey, 'secret passphrase');
+
+$spkac = openssl_spki_new($pkey, 'challenge string');
+?>
+]]>
+      </programlisting>
+      &example.outputs;
+      <screen>
+<![CDATA[
+SPKAC=MIIBXjCByDCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEA3L0IfUijj7+A8CPC8EmhcdNoe5fUAog7OrBdhn7EkxFButUp40P7+LiYiygYG1TmoI/a5EgsLU3s9twEz3hmgY9mYIqb/rb+SF8qlD/K6KVyUORC7Wlz1Df4L8O3DuRGzx6/+3jIW6cPBpfgH1sVuYS1vDBsP/gMMIxwTsKJ4P0CAwEAARYkYjViMzYxMTktNjY5YS00ZDljLWEyYzctMGZjNGFhMjVlMmE2MA0GCSqGSIb3DQEBAwUAA4GBAF7hu0ifzmjonhAak2FhhBRsKFDzXdKIkrWxVNe8e0bZzMrWOxFM/rqBgeH3/gtOUDRS5Fnzyq425UsTYbjfiKzxGeCYCQJb1KJ2V5Ij/mIJHZr53WYEXHQTNMGR8RPm7IxwVXVSHIgAfXsXZ9IXNbFbcaLRiSTr9/N4U+MXUWL7
+]]>
+      </screen>
+     </informalexample>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry>
+    <term><parameter>openssl_spki_verify</parameter></term>
+    <listitem>
+     <para>
+      验证提供的 SPKAC。
+     </para>
+
+     <informalexample>
+      <programlisting role="php">
+<![CDATA[
+<?php
+$pkey = openssl_pkey_new();
+openssl_pkey_export($pkey, 'secret passphrase');
+
+$spkac = openssl_spki_new($pkey, 'challenge string');
+var_dump(openssl_spki_verify($spkac));
+?>
+]]>
+      </programlisting>
+     </informalexample>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry>
+    <term><parameter>openssl_spki_export_challenge</parameter></term>
+    <listitem>
+     <para>
+      从提供的 SPKAC 导出关联的挑战。
+     </para>
+
+     <informalexample>
+      <programlisting role="php">
+<![CDATA[
+<?php
+$pkey = openssl_pkey_new();
+openssl_pkey_export($pkey, 'secret passphrase');
+
+$spkac = openssl_spki_new($pkey, 'challenge string');
+$challenge = openssl_spki_export_challenge($spkac);
+echo $challenge;
+?>
+]]>
+      </programlisting>
+      &example.outputs;
+      <screen>
+<![CDATA[
+challenge string
+]]>
+      </screen>
+     </informalexample>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry>
+    <term><parameter>openssl_spki_export</parameter></term>
+    <listitem>
+     <para>
+      从 SPKAC 导出 <acronym>PEM</acronym> 格式的 RSA 公钥。
+     </para>
+
+     <informalexample>
+      <programlisting role="php">
+<![CDATA[
+<?php
+$pkey = openssl_pkey_new();
+openssl_pkey_export($pkey, 'secret passphrase');
+
+$spkac = openssl_spki_new($pkey, 'challenge string');
+echo openssl_spki_export($spkac);
+?>
+]]>
+      </programlisting>
+      &example.outputs;
+      <screen>
+<![CDATA[
+-----BEGIN PUBLIC KEY-----
+MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDcvQh9SKOPv4DwI8LwSaFx02h7
+l9QCiDs6sF2GfsSTEUG61SnjQ/v4uJiLKBgbVOagj9rkSCwtTez23ATPeGaBj2Zg
+ipv+tv5IXyqUP8ropXJQ5ELtbXPUN/gvw7cO5EbPHr/7eMhbpw8Gl+AfWxW5hLW8
+MGw/+AwwjHBOwong/QIDAQAB
+-----END PUBLIC KEY-----
+]]>
+      </screen>
+     </informalexample>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </sect2>
+</sect1>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
使用了自定义智能体翻译。具体如下，可以在 vscode copilot 中直接使用

```md
---
description: "用于在 XML 文件中将 PHP 手册文档从英文翻译为中文时使用，遵循 php/doc-zh 规则。不要修改 XML 标签，只翻译标签内的文本。"
name: "PHP 文档翻译器"
tools: [read, edit, search, execute]
user-invocable: true
---
您是一位将 PHP 手册文档从英文翻译为中文的专家。

您的任务是将 XML 标签内的英文文本翻译为中文，遵循 https://github.com/php/doc-zh 的规则。

## 约束条件
- 不要修改 XML 标签或结构
- 仅翻译标签内的英文文本内容
- 遵循 php/doc-zh 仓库的翻译规则
- 文件是 UNIX 的文件格式而不是 DOS 的，也就是文件中的换行标记只有换行符（\n），而没有回车符（\r）。并且在文件中不要使用 （制表符\t）而要使用空格
- 请注意翻译中的标点问题，使用中文标点符号
- 中英文字词之间使用空格分开，与中文标点之间就不要有空格了
- 不需要翻译的 xml 标签：function、constant、parameter、programlisting、programlisting、screen
- 只要是 &xxx; xxx表示任意字符，只要满足这个规则的就不需要翻译。具体示例：&true;、&false;
- 完成整个文件的翻译后，再运行 bin/check.sh 来验证语法，不要在翻译过程中频繁运行检查脚本

## 方法
1. 读取 XML 文件以了解结构
2. 识别需要翻译的英文文本
3. 按照规则将文本翻译为中文
4. 编辑文件，将英文替换为中文，同时保留标签，完成整个文件的所有翻译
5. 全部翻译完成后，运行 bin/check.sh 来检查语法错误

## 输出格式
确认翻译完成且语法检查通过，或报告检查脚本发现的问题。
```

开发了一个专门翻译中文的工具：https://github.com/singi2016cn/doc-zh-tool