### PR TITLE
新增 Yac 扩展文档的中文翻译

### DIFF
--- a/reference/yac/book.xml
+++ b/reference/yac/book.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: d3a03f8f542cd083d793bbd8ef3d7756aae7711f Maintainer: Laruence Status: ready -->
+
+<book xml:id="book.yac" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
+ <title>Yac</title>
+ <titleabbrev>Yac</titleabbrev>
+
+ <preface xml:id="intro.yac">
+  &reftitle.intro;
+  <simpara>
+   Yac（Yet Another Cache）是一个无锁（lock-free）的共享内存用户数据缓存，
+   可以用来替代 APC 或本地 memcached。
+  </simpara>
+  <simpara>
+   Yac 将数据存储在共享内存中，同一台机器上的每个 PHP 工作进程
+   都能直接访问，无需任何进程间通信。
+   Yac 不加锁，而是依靠原子的槽位更新加上少量的冲突探测，
+   因此缓存未命中（cache miss）绝不会阻塞请求；
+   并发写入最坏的情况也只是某次存储失败或某次读取落空，
+   调用方直接重试即可。
+  </simpara>
+  <simpara>
+   访问路径上没有锁，也没有进程间通信，一次读取本质上就是
+   在共享内存中做一次哈希查找。因此，Yac 极其快，
+   读取延迟在微秒级；只要写入分散在不同的键上，
+   吞吐量还能随着访问缓存的 worker 数量增长。
+  </simpara>
+  <simpara>
+   由于 Yac 用正确性保证换取速度和吞吐量，
+   它最适合缓存那些生成代价高但可以轻易重建的数据：
+   页面片段、配置快照、小型服务响应等本地缓存。
+   不要把它用作不可替代数据的权威存储。
+  </simpara>
+  <simpara>
+   从 yac 2.4.0 开始，小标量值——<constant>NULL</constant>、
+   布尔值、整数、最长 7 字节的短字符串和空数组——
+   直接存储在哈希槽（hash slot）里，而不是单独的值块
+   （即“嵌入值”，embedded values）。这样每次访问都省去了
+   值内存的分配和块拷贝，显著提升性能的同时减少了内存占用。
+   2.4.0 还把压缩后端从 FastLZ 换成了 LZ4，
+   使压缩数据的读取快了好几倍。
+  </simpara>
+  <note>
+   <simpara>
+    共享内存仅在同一台机器内可见。
+    如果需要在多台服务器之间共享缓存，
+    请使用 Memcached 或 Redis 等网络缓存。
+   </simpara>
+  </note>
+ </preface>
+
+ &reference.yac.setup;
+ &reference.yac.constants;
+ <!-- &reference.yac.examples; -->
+ &reference.yac.yac;
+
+</book>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/yac/constants.xml
+++ b/reference/yac/constants.xml
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: Laruence Status: ready -->
+
+<appendix xml:id="yac.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ &reftitle.constants;
+ &extension.constants;
+ <para>
+  <variablelist>
+   <varlistentry xml:id="constant.yac-version">
+    <term>
+     <constant>YAC_VERSION</constant>
+     (<type>string</type>)
+    </term>
+    <listitem>
+     <simpara>
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.yac-max-key-len">
+    <term>
+     <constant>YAC_MAX_KEY_LEN</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      键允许的最大长度，为 48 字节。
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.yac-max-value-raw-len">
+    <term>
+     <constant>YAC_MAX_VALUE_RAW_LEN</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.yac-max-raw-compressed-len">
+    <term>
+     <constant>YAC_MAX_RAW_COMPRESSED_LEN</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.yac-serializer-php">
+    <term>
+     <constant>YAC_SERIALIZER_PHP</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      使用 PHP serialize 作为序列化器。
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.yac-serializer-json">
+    <term>
+     <constant>YAC_SERIALIZER_JSON</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      使用 JSON 作为序列化器（需要 --enable-json）。
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.yac-serializer-igbinary">
+    <term>
+     <constant>YAC_SERIALIZER_IGBINARY</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      使用 igbinary 作为序列化器（需要 --enable-igbinary）。
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.yac-serializer-msgpack">
+    <term>
+     <constant>YAC_SERIALIZER_MSGPACK</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      使用 msgpack 作为序列化器（需要 --enable-msgpack）。
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.yac-serializer">
+    <term>
+     <constant>YAC_SERIALIZER</constant>
+     (<type>string</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Yac 当前使用的序列化器。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </para>
+</appendix>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/yac/ini.xml
+++ b/reference/yac/ini.xml
@@ -1,0 +1,191 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: Laruence Status: ready -->
+
+<section xml:id="yac.configuration" xmlns="http://docbook.org/ns/docbook">
+ &reftitle.runtime;
+ &extension.runtime;
+ <para>
+  <table>
+   <title>Yac &ConfigureOptions;</title>
+   <tgroup cols="4">
+    <thead>
+     <row>
+      <entry>&Name;</entry>
+      <entry>&Default;</entry>
+      <entry>&Changeable;</entry>
+      <entry>&Changelog;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry><link linkend="ini.yac.compress-threshold">yac.compress_threshold</link></entry>
+      <entry>-1</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
+      <entry><!-- leave empty, this will be filled by an automatic script --></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.yac.debug">yac.debug</link></entry>
+      <entry>0</entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry><!-- leave empty, this will be filled by an automatic script --></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.yac.enable">yac.enable</link></entry>
+      <entry>1</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
+      <entry><!-- leave empty, this will be filled by an automatic script --></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.yac.enable-cli">yac.enable_cli</link></entry>
+      <entry>0</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
+      <entry><!-- leave empty, this will be filled by an automatic script --></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.yac.keys-memory-size">yac.keys_memory_size</link></entry>
+      <entry>4M</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
+      <entry><!-- leave empty, this will be filled by an automatic script --></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.yac.serializer">yac.serializer</link></entry>
+      <entry>php</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
+      <entry><!-- leave empty, this will be filled by an automatic script --></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.yac.values-memory-size">yac.values_memory_size</link></entry>
+      <entry>64M</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
+      <entry><!-- leave empty, this will be filled by an automatic script --></entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </table>
+ </para>
+
+ &ini.descriptions.title;
+
+ <para>
+  <variablelist>
+   <varlistentry xml:id="ini.yac.compress-threshold">
+     <term>
+      <parameter>yac.compress_threshold</parameter>
+      <type>int</type>
+     </term>
+     <listitem>
+      <simpara>
+       序列化后大于该字节数的值会在存储前被压缩（当前使用 LZ4）。
+       设为 <literal>-1</literal>（默认值）则完全禁用压缩。
+       压缩大值可以节省共享内存，代价是存取时多消耗一些 CPU。
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="ini.yac.debug">
+     <term>
+      <parameter>yac.debug</parameter>
+      <type>int</type>
+     </term>
+     <listitem>
+      <simpara>
+       保留给调试用。截至 Yac 2.4.0，该配置项已注册但没有任何效果。
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="ini.yac.enable">
+     <term>
+      <parameter>yac.enable</parameter>
+      <type>int</type>
+     </term>
+     <listitem>
+      <simpara>
+       是否启用 Yac。如果被禁用，创建
+       <classname>Yac</classname> 实例会抛出异常。
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="ini.yac.enable-cli">
+     <term>
+      <parameter>yac.enable_cli</parameter>
+      <type>int</type>
+     </term>
+     <listitem>
+      <simpara>
+       在 <literal>CLI</literal> SAPI 下运行时是否启用 Yac。
+       默认禁用，因为命令行脚本通常启动后立即结束，
+       创建共享内存段毫无意义。
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="ini.yac.keys-memory-size">
+     <term>
+      <parameter>yac.keys_memory_size</parameter>
+      <type>string</type>
+     </term>
+     <listitem>
+      <simpara>
+       用于存放键和元信息的哈希槽位所占用的共享内存大小。
+       每个槽位是固定大小的结构，因此这个值决定了能同时跟踪多少条目。
+       默认为 <literal>4M</literal>。
+       Yac 将这块区域切分成若干段，每段大小为 4M，
+       因此该值必须是 <literal>4M</literal> 的倍数。
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="ini.yac.serializer">
+     <term>
+      <parameter>yac.serializer</parameter>
+      <type>string</type>
+     </term>
+     <listitem>
+      <simpara>
+       存储前把任意 PHP 值转换成字节序列所用的序列化器。
+       可选值为 <literal>php</literal>（默认）、<literal>json</literal>、
+       <literal>igbinary</literal> 和 <literal>msgpack</literal>。
+       后三者需要扩展以相应支持编译。
+       <literal>igbinary</literal> 和 <literal>msgpack</literal>
+       等二进制序列化器通常比 <literal>php</literal> 更快，
+       产生的数据也更小。
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="ini.yac.values-memory-size">
+     <term>
+      <parameter>yac.values_memory_size</parameter>
+      <type>string</type>
+     </term>
+     <listitem>
+      <simpara>
+       用于存放实际值的共享内存大小，默认为 <literal>64M</literal>。
+       Yac 以每段 4M 的方式分配这块区域，
+       因此该值必须是 <literal>4M</literal> 的倍数。
+       当区域写满时，最久未使用的条目会被踢出，为新条目腾出空间。
+      </simpara>
+     </listitem>
+    </varlistentry>
+
+  </variablelist>
+ </para>
+</section>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/yac/setup.xml
+++ b/reference/yac/setup.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: d3a03f8f542cd083d793bbd8ef3d7756aae7711f Maintainer: Laruence Status: ready -->
+
+<chapter xml:id="yac.setup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ &reftitle.setup;
+
+ <section xml:id="yac.requirements">
+  &reftitle.required;
+  <simpara>
+   无需外部库。
+  </simpara>
+ </section>
+
+ <!-- {{{ Installation -->
+ <section xml:id="yac.installation">
+  &reftitle.install;
+  <simpara>
+   Yac 有三种安装方式：通过 PECL、通过 PIE，或从源码构建。
+  </simpara>
+  <simpara>
+   &pecl.moved;
+  </simpara>
+  <simpara>
+   &pecl.info;
+   <link xlink:href="&url.pecl.package;yac">&url.pecl.package;yac</link>。
+  </simpara>
+  <simpara>
+   &pecl.windows.download.avail;
+  </simpara>
+  <example>
+   <title>用 PECL 安装 Yac</title>
+   <programlisting role="shell">
+<![CDATA[
+pecl install yac
+]]>
+   </programlisting>
+  </example>
+  <simpara>
+   从 Yac 2.3.2 开始，可以用 &link.pie;（PHP Installer for
+   Extensions，PHP 扩展安装器）安装本扩展，在命令行执行：
+  </simpara>
+  <example>
+   <title>用 PIE 安装 Yac</title>
+   <programlisting role="shell">
+<![CDATA[
+pie install laruence/yac
+]]>
+   </programlisting>
+  </example>
+  <simpara>
+   安装时可以同时启用可选的序列化器：
+  </simpara>
+  <example>
+   <title>用 PIE 安装 Yac 并启用序列化器</title>
+   <programlisting role="shell">
+<![CDATA[
+pie install laruence/yac --enable-json
+]]>
+   </programlisting>
+  </example>
+  <simpara>
+   源代码托管在
+   <link xlink:href="&url.git.hub;laruence/yac">GitHub</link> 上。
+   从源码构建扩展，在命令行执行以下命令，
+   并把路径替换为本地 PHP 安装的实际路径：
+  </simpara>
+  <example>
+   <title>从源码构建 Yac</title>
+   <programlisting role="shell">
+<![CDATA[
+/path/to/phpize
+./configure --with-php-config=/path/to/php-config
+make && make install
+]]>
+   </programlisting>
+  </example>
+  <simpara>
+   可用的 <literal>configure</literal> 选项如下：
+  </simpara>
+  <simpara>
+   值在存储前会用 LZ4 压缩。LZ4 压缩后端从 Yac 2.4.0 开始使用，
+   取代了此前的 FastLZ。默认情况下，Yac 使用随扩展一起打包的
+   LZ4 副本，无需额外的编译选项。如果要改为链接系统的 LZ4 库，
+   请使用 <option role="configure">--with-system-lz4</option> 选项，
+   这要求系统已安装 <literal>lz4.h</literal> 头文件和
+   <literal>liblz4</literal>。
+  </simpara>
+  <simpara>
+   可以通过 <option role="configure">--enable-json</option>、
+   <option role="configure">--enable-msgpack</option> 或
+   <option role="configure">--enable-igbinary</option>
+   编译进备选的序列化器，相应的扩展会被注册为可选依赖。
+   运行时使用哪个序列化器由
+   <link linkend="ini.yac.serializer">yac.serializer</link>
+   ini 配置项选择。
+  </simpara>
+ </section>
+ <!-- }}} -->
+
+ <!-- {{{ Configuration -->
+ &reference.yac.ini;
+ <!-- }}} -->
+
+ <section xml:id="yac.resources">
+  &reftitle.resources;
+  <simpara>
+   此扩展没有定义任何资源类型。
+  </simpara>
+ </section>
+
+</chapter>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/yac/yac.xml
+++ b/reference/yac/yac.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: d3a03f8f542cd083d793bbd8ef3d7756aae7711f Maintainer: Laruence Status: ready -->
+
+<reference xml:id="class.yac" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+
+ <title>Yac 类</title>
+ <titleabbrev>Yac</titleabbrev>
+
+ <partintro>
+
+<!-- {{{ Yac intro -->
+  <section xml:id="yac.intro">
+   &reftitle.intro;
+   <simpara>
+    <classname>Yac</classname> 类是访问缓存的接口。
+    同一台主机上的每个实例都是同一个共享缓存的轻量级句柄：
+    所有实例读写同一份数据，创建一个实例除了句柄本身之外
+    没有任何额外分配。
+   </simpara>
+   <simpara>
+    传给 <methodname>Yac::__construct</methodname> 的可选前缀
+    会被拼接到每个键的前面，这样多个实例（或多个应用）
+    可以共用同一个缓存而键互不冲突。除了常规的缓存操作
+    （<methodname>Yac::add</methodname>、
+    <methodname>Yac::set</methodname>、
+    <methodname>Yac::get</methodname>、
+    <methodname>Yac::delete</methodname> 和
+    <methodname>Yac::flush</methodname>）之外，该类还提供
+    <methodname>Yac::info</methodname> 和
+    <methodname>Yac::dump</methodname> 用于检视缓存，
+    并且重载了属性访问——读写对象属性就是读写一个缓存条目。
+   </simpara>
+  </section>
+<!-- }}} -->
+
+  <section xml:id="yac.synopsis">
+   &reftitle.classsynopsis;
+
+<!-- {{{ Synopsis -->
+   <classsynopsis>
+    <ooclass><classname>Yac</classname></ooclass>
+
+<!-- {{{ Class synopsis -->
+    <classsynopsisinfo>
+     <ooclass>
+      <classname>Yac</classname>
+     </ooclass>
+    </classsynopsisinfo>
+<!-- }}} -->
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>protected</modifier>
+     <varname linkend="yac.props.prefix">_prefix</varname>
+    </fieldsynopsis>
+
+
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yac')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])" />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yac')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
+   </classsynopsis>
+<!-- }}} -->
+
+  </section>
+
+
+<!-- {{{ Yac properties -->
+  <section xml:id="yac.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="yac.props.prefix">
+     <term><varname>_prefix</varname></term>
+     <listitem>
+      <simpara>
+       通过 <methodname>Yac::__construct</methodname> 设置的键前缀。
+       它会拼接到该实例使用的每个键的前面；拼接时不会自动插入
+       分隔符，需要的话请自己包含在前缀里。前缀长度不能超过
+       <constant>YAC_MAX_KEY_LEN</constant>（48）字节。
+      </simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
+
+
+ </partintro>
+
+ &reference.yac.entities.yac;
+
+</reference>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/yac/yac/add.xml
+++ b/reference/yac/yac/add.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: Laruence Status: ready -->
+
+<refentry xml:id="yac.add" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Yac::add</refname>
+  <refpurpose>存储一个值，但不覆盖已有条目</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>bool</type><methodname>Yac::add</methodname>
+   <methodparam><type class="union"><type>string</type><type>array</type></type><parameter>keys</parameter></methodparam>
+   <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>ttl</parameter><initializer>0</initializer></methodparam>
+  </methodsynopsis>
+  <methodsynopsis>
+   <modifier>public</modifier> <type>bool</type><methodname>Yac::add</methodname>
+   <methodparam><type>array</type><parameter>values</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>ttl</parameter><initializer>0</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   向缓存中存储一个值。与 <methodname>Yac::set</methodname> 不同，
+   它不会覆盖仍然有效的已有条目；遇到这种情况时存储会被拒绝。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>keys</parameter></term>
+    <listitem>
+     <simpara>
+      <type>string</type> 类型的键，或者一个由
+      <literal>key =&gt; value</literal> 键值对组成的
+      <type>array</type>，一次调用存储多个条目。
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>value</parameter></term>
+    <listitem>
+     <simpara>
+      要存储的值。除 <type>resource</type> 外的所有 PHP 类型都可以存储。
+      仅在单键形式下使用；当 <parameter>keys</parameter> 是数组时，
+      该参数位置实际上是可选的 <parameter>ttl</parameter>。
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>ttl</parameter></term>
+    <listitem>
+     <simpara>
+      生存时间，单位为秒。<literal>0</literal> 表示条目永不因时间过期。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   成功时返回 &true;，失败时返回 &false;。
+   当键已存在且未过期时，存储同样会被拒绝（返回 &false;）。
+  </simpara>
+  <note>
+   <para>
+    Yac 存储条目时不加锁。在高并发竞争下，存储可能会瞬时失败；
+    如果该值必须最终写入成功，请重试：
+    <programlisting role="php">
+<![CDATA[
+<?php
+while (!$yac->add("key", "value")) {
+    // 瞬时失败时重试
+}
+?>
+]]>
+    </programlisting>
+   </para>
+  </note>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><methodname>Yac::add</methodname> 示例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$yac = new Yac();
+
+var_dump($yac->add("foo", "bar"));          // bool(true)
+var_dump($yac->add("foo", "baz"));          // bool(false)："foo" 已存在
+
+// ttl 以秒为单位；0（默认值）表示条目永不过期
+$yac->add("short-lived", "value", 5);
+sleep(6);
+var_dump($yac->get("short-lived"));        // bool(false)：已过期
+
+// 一次调用存储多个键值对，并指定 ttl
+$yac->add(array("a" => 1, "b" => 2), 60);
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>Yac::set</methodname></member>
+    <member><methodname>Yac::get</methodname></member>
+    <member><methodname>Yac::delete</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/yac/yac/construct.xml
+++ b/reference/yac/yac/construct.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: Laruence Status: ready -->
+
+<refentry xml:id="yac.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Yac::__construct</refname>
+  <refpurpose>构造函数</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <constructorsynopsis>
+   <modifier>public</modifier> <methodname>Yac::__construct</methodname>
+   <methodparam choice="opt"><type>string</type><parameter>prefix</parameter><initializer>""</initializer></methodparam>
+  </constructorsynopsis>
+  <simpara>
+   创建一个新的 <classname>Yac</classname> 实例。
+   可选的 <parameter>prefix</parameter> 会被添加到该实例存储的每个键前面，
+   这样同一台机器上的多个应用或缓存就可以使用重叠的键名而互不冲突。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>prefix</parameter></term>
+    <listitem>
+     <simpara>
+      键前缀，最长 48 字节（<constant>YAC_MAX_KEY_LEN</constant>）。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   当缓存被禁用（<literal>yac.enable=0</literal>）
+   或 <parameter>prefix</parameter> 超过 48 字节时，
+   会抛出 <exceptionname>Exception</exceptionname>。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><methodname>Yac::__construct</methodname> 示例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$yac = new Yac();
+$yac->set("foo", "bar");
+
+$other = new Yac("app2_");
+var_dump($other->get("foo"));    // bool(false)：不同的命名空间
+$other->set("foo", "baz");       // 实际存储的键是 "app2_foo"
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>Yac::set</methodname></member>
+    <member><methodname>Yac::get</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/yac/yac/delete.xml
+++ b/reference/yac/yac/delete.xml
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: d3a03f8f542cd083d793bbd8ef3d7756aae7711f Maintainer: Laruence Status: ready -->
+
+<refentry xml:id="yac.delete" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Yac::delete</refname>
+  <refpurpose>从缓存中删除条目</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>bool</type><methodname>Yac::delete</methodname>
+   <methodparam><type class="union"><type>string</type><type>array</type></type><parameter>keys</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>delay</parameter><initializer>0</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   从缓存中删除一个或多个条目。
+  </simpara>
+  <note>
+   <simpara>
+    注意，Yac 并不会真正把条目从缓存中移除：删除只是把条目标记为
+    过期——<literal>delay</literal> 为 <literal>0</literal> 时立即过期——
+    只有当后续的写入恰好复用了这个哈希槽时，该条目才会被覆盖：
+    要么是同一个键被重新写入，要么是另一个键的插入恰好落在了这个槽上。
+    在那之前，槽位一直被占用，所以 <methodname>Yac::info</methodname>
+    报告的 <literal>slots_used</literal> 计数不会减少，
+    <methodname>Yac::dump</methodname> 也仍会列出这些已删除的条目；
+    检视 dump 输出时，需要自己检查 <literal>ttl</literal> 值把它们过滤掉。
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>keys</parameter></term>
+    <listitem>
+     <simpara>
+      <type>string</type> 类型的键，或者由待删除的键组成的
+      <type>array</type>。
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>delay</parameter></term>
+    <listitem>
+     <simpara>
+      条目变为失效前等待的秒数。省略或为 <literal>0</literal>
+      时，条目立即失效。正数值表示条目在这段时间内仍可读，
+      到期后才失效。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   成功时返回 &true;；键不在缓存中时返回 &false;。
+   由于删除只是把条目标记为过期，一个已删除但尚未被覆盖的键
+   仍然算作存在：再次删除同一个键会返回 &true;。
+  </simpara>
+  <simpara>
+   传入键的 <type>array</type> 时，只有当每个键都存在才返回
+   &true;；只要有任何一个键缺失，就返回 &false;。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><methodname>Yac::delete</methodname> 示例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$yac = new Yac();
+$yac->set("foo", "bar");
+
+var_dump($yac->delete("foo"));      // bool(true)：标记为过期
+var_dump($yac->get("foo"));         // bool(false)：从此读取都是未命中
+var_dump($yac->delete("foo"));      // bool(true)：槽位还没被覆盖，所以又成功
+var_dump($yac->delete("never"));    // bool(false)：从未存储过
+
+// 删除不会释放槽位：slots_used 不减少，
+// 已过期的条目仍然出现在 dump 里
+var_dump($yac->info()["slots_used"]); // int(1)
+print_r($yac->dump());                // "foo" 仍在列表中；其 ttl 已过期
+
+// 延迟删除：让条目再保持可读 60 秒
+$yac->set("tmp", "value");
+var_dump($yac->delete("tmp", 60));    // bool(true)
+
+// 一次删除多个键时，只有当每个键都存在才返回 true
+var_dump($yac->delete(array("tmp", "nope"))); // bool(false)："nope" 不存在
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>Yac::set</methodname></member>
+    <member><methodname>Yac::flush</methodname></member>
+    <member><methodname>Yac::info</methodname></member>
+    <member><methodname>Yac::dump</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/yac/yac/dump.xml
+++ b/reference/yac/yac/dump.xml
@@ -1,0 +1,281 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: d3a03f8f542cd083d793bbd8ef3d7756aae7711f Maintainer: Laruence Status: ready -->
+
+<refentry xml:id="yac.dump" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Yac::dump</refname>
+  <refpurpose>导出缓存条目以便检查</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>array</type><methodname>Yac::dump</methodname>
+   <methodparam choice="opt"><type>int</type><parameter>limit</parameter><initializer>100</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>offset</parameter><initializer>0</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   导出当前缓存储存的条目的元数据。值本身不会被返回。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>limit</parameter></term>
+    <listitem>
+     <simpara>
+      返回条目的最大数量。
+     </simpara>
+     <simpara>
+      <parameter>limit</parameter> 传 <literal>-1</literal> 会导出缓存当前持有的全部条目。
+      注意，对大型缓存构建完整列表可能占用可观的内存；
+      内存紧张时，请改用 <parameter>limit</parameter> 和 <parameter>offset</parameter> 分页遍历。
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>offset</parameter></term>
+    <listitem>
+     <simpara>
+      收集前跳过的条目数。该参数自 PECL yac 2.4.0 起可用；
+      更早的版本总是从第一个条目开始。结合 <parameter>limit</parameter>，
+      可用于对储存条目超过单次调用返回上限的缓存进行分页遍历。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   返回一个 <type>array</type>，每个导出的条目对应一个元素。
+   每个元素本身也是描述该条目的数组：
+  </simpara>
+  <variablelist>
+   <varlistentry>
+    <term><literal>index</literal></term>
+    <listitem><simpara>
+     条目在哈希表中的槽位索引。
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>hash</literal></term>
+    <listitem><simpara>
+     键的 64 位哈希值，用于槽位探测。
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>crc</literal></term>
+    <listitem><simpara>
+     存储值的 CRC32 校验和，用于检测撕裂读取（torn read）。
+     内嵌（embedded）条目没有值块，该字段为 <literal>0</literal>。
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>ttl</literal></term>
+    <listitem><simpara>
+     过期时间戳（Unix 时间）。<literal>0</literal>
+     表示条目永不因时间过期。注意 <methodname>Yac::delete</methodname>
+     只是把条目标记为过期，因此已删除的条目仍可能出现在导出结果中；
+     <literal>ttl</literal> 非零且在过去，表明条目已过期或已被删除。
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>k_len</literal></term>
+    <listitem><simpara>
+     键的长度，单位为字节。
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>v_len</literal></term>
+    <listitem><simpara>
+     值的长度，单位为字节。对于被压缩的条目，
+     这是压缩<emphasis>前</emphasis>原始值的长度
+     （自 yac 2.4.0 起；更早的版本报告的是存储的压缩后长度）。
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>c_len</literal></term>
+    <listitem><simpara>
+     仅被压缩的条目有此字段（自 yac 2.4.0 起）：
+     实际存入共享内存的压缩数据长度，单位为字节。
+     对比 <literal>c_len</literal> 和 <literal>v_len</literal>
+     可以看出每个条目通过压缩节省了多少空间。
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>size</literal></term>
+    <listitem><simpara>
+     值块在共享内存中分配的大小，单位为字节。
+     内嵌条目为 <literal>0</literal>。
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>atime</literal></term>
+    <listitem><simpara>
+     最后访问时间（Unix 时间），每次成功的
+     <methodname>Yac::get</methodname> 都会更新它。
+     缓存写满时，候选槽位中 <literal>atime</literal>
+     最旧的条目会最先被驱逐（自 yac 2.4.0 起）。
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>hits</literal></term>
+    <listitem><simpara>
+     每个条目的命中计数器，每次成功的
+     <methodname>Yac::get</methodname> 都会使其递增；
+     条目被覆盖、删除或过期时重置（自 yac 2.4.0 起）。
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>embedded</literal></term>
+    <listitem><simpara>
+     值是否直接存储在槽位内部，而不是单独的值块中
+     （自 yac 2.4.0 起）。小值——<constant>NULL</constant>、
+     布尔值、小整数、不超过 7 字节的字符串和空数组——
+     以内嵌方式存储，完全不占用值内存；
+     这类条目的 <literal>crc</literal> 和 <literal>size</literal>
+     均报告为 <literal>0</literal>。
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>key</literal></term>
+    <listitem><simpara>
+     缓存键，不包含实例前缀。
+    </simpara></listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><methodname>Yac::dump</methodname> 示例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$yac = new Yac();
+$yac->set("foo", "bar");
+$yac->set("baz", "qux");
+
+print_r($yac->dump());
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+Array
+(
+    [0] => Array
+        (
+            [index] => 12345
+            [hash] => 14463105906481965911
+            [crc] => 0
+            [ttl] => 0
+            [k_len] => 3
+            [v_len] => 3
+            [size] => 0
+            [atime] => 1725955200
+            [hits] => 0
+            [embedded] => 1
+            [key] => foo
+        )
+
+    [1] => Array
+        (
+            [index] => 12987
+            [hash] => 15132029420525657053
+            [crc] => 0
+            [ttl] => 0
+            [k_len] => 3
+            [v_len] => 3
+            [size] => 0
+            [atime] => 1725955200
+            [hits] => 0
+            [embedded] => 1
+            [key] => baz
+        )
+
+)
+]]>
+   </screen>
+   <simpara>
+    条目按槽位顺序列出，而不是按存储顺序。
+    内嵌条目（直接保存在槽位内部的小标量）的
+    <literal>crc</literal> 和 <literal>size</literal> 为零；
+    存储在独立值块中的条目带有校验和与块大小，
+    被压缩的条目还额外带有 <literal>c_len</literal>。
+   </simpara>
+  </example>
+  <example>
+   <title>分页遍历大型缓存</title>
+   <simpara>
+    <parameter>limit</parameter> 限制单次调用返回的条目数，
+    <parameter>offset</parameter> 表示收集前跳过的条目数，
+    两者组合即可对储存条目超过单次调用返回上限的缓存进行分页遍历。
+   </simpara>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$yac = new Yac();
+
+$page_size = 100;
+$page_num  = 2;
+
+// 跳过前 100 个条目，返回接下来的 100 个（第 2 页）
+$page = $yac->dump($page_size, $page_size * ($page_num - 1));
+
+var_dump(count($page));
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+int(100)
+]]>
+   </screen>
+   <simpara>
+    当缓存中的条目数少于请求页覆盖的范围时，
+    返回的条目数会少于请求数；
+    当 offset 指向最后一个已占用槽位之后时，返回空数组。
+   </simpara>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>Yac::info</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/yac/yac/flush.xml
+++ b/reference/yac/yac/flush.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: Laruence Status: ready -->
+
+<refentry xml:id="yac.flush" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Yac::flush</refname>
+  <refpurpose>清空缓存</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>bool</type><methodname>Yac::flush</methodname>
+   <void />
+  </methodsynopsis>
+  <simpara>
+   删除所有缓存的值。由于缓存由同一台机器上的所有进程共享，
+   这会全局清空缓存；传给 <methodname>Yac::__construct</methodname>
+   的键前缀不会限制清空的范围。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   返回 &true;。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><methodname>Yac::flush</methodname> 示例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$yac = new Yac();
+$yac->set("foo", "bar");
+
+$other = new Yac("app2_");
+$other->set("baz", "qux");
+
+// flush 会清空整个缓存：所有实例的条目，
+// 无论存储时使用了什么前缀
+$yac->flush();
+
+var_dump($yac->get("foo"));   // bool(false)
+var_dump($other->get("baz")); // bool(false)
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>Yac::delete</methodname></member>
+    <member><methodname>Yac::info</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/yac/yac/get.xml
+++ b/reference/yac/yac/get.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: Laruence Status: ready -->
+
+<refentry xml:id="yac.get" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Yac::get</refname>
+  <refpurpose>从缓存中取值</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>mixed</type><methodname>Yac::get</methodname>
+   <methodparam><type class="union"><type>string</type><type>array</type></type><parameter>keys</parameter></methodparam>
+   <methodparam choice="opt"><type>mixed</type><parameter>default</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   从缓存中取值。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>keys</parameter></term>
+    <listitem>
+     <simpara>
+      <type>string</type> 类型的键，或者由键组成的 <type>array</type>。
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>default</parameter></term>
+    <listitem>
+     <simpara>
+      当请求的键（或多个键）不在缓存中时返回的值，
+      自 yac 2.4.0 起可用。省略时，未命中返回 &false;。
+     </simpara>
+     <note>
+      <simpara>
+       在 yac 2.4.0 之前，该参数位置是一个引用形式的
+       <literal>$cas</literal> 令牌，而不是默认值。
+       传递过或依赖该令牌的代码在升级到 2.4.0 时必须更新。
+      </simpara>
+     </note>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   对于 <type>string</type> 类型的键，命中时返回缓存的值，
+   否则返回 <parameter>default</parameter>（未指定默认值时返回 &false;）。
+  </simpara>
+  <simpara>
+   对于由键组成的 <type>array</type>，返回一个数组，
+   其中包含所有命中的值，以各自的键为索引。
+   自 yac 2.4.0 起，不在缓存中的键会被直接忽略
+   （若指定了 <parameter>default</parameter>，则用默认值填充）；
+   在 2.4.0 之前，每个缺失的键都会插入一个 &false; 占位值。
+  </simpara>
+ </refsect1>
+
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><methodname>Yac::get</methodname> 示例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$yac = new Yac();
+
+$yac->set("foo", "bar");
+var_dump($yac->get("foo"));                 // string(3) "bar"
+var_dump($yac->get("missing"));             // bool(false)：未命中
+
+// 没有默认值时，未命中和存了 false 无法区分；
+// 哨兵默认值（自 yac 2.4.0 起可用）可以区分二者
+$yac->set("flag", false);
+var_dump($yac->get("flag"));                // bool(false)：存的就是这个值
+var_dump($yac->get("missing", false));      // bool(false)：未命中，形态相同
+var_dump($yac->get("flag", "__NONE__"));    // bool(false)：存的就是这个值
+var_dump($yac->get("missing", "__NONE__")); // string(8) "__NONE__"：未命中
+
+// 传入键数组时，结果中只包含命中的键
+$yac->set("foo2", "bar2");
+var_dump($yac->get(array("foo", "foo2", "missing")));
+// array(2) { ["foo"]=> string(3) "bar" ["foo2"]=> string(4) "bar2" }
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>Yac::set</methodname></member>
+    <member><methodname>Yac::__get</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/yac/yac/getter.xml
+++ b/reference/yac/yac/getter.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: Laruence Status: ready -->
+
+<refentry xml:id="yac.getter" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Yac::__get</refname>
+  <refpurpose>以属性语法取值</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>mixed</type><methodname>Yac::__get</methodname>
+   <methodparam><type>string</type><parameter>key</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   从缓存中取值，读取 <classname>Yac</classname> 实例的属性时被调用：
+   <literal>$yac->foo</literal> 等价于
+   <literal>$yac->get("foo")</literal>。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>key</parameter></term>
+    <listitem>
+     <simpara>
+      属性名，被用作缓存键。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   命中时返回缓存的值；键不在缓存中时返回 &null;。
+  </simpara>
+  <note>
+   <simpara>
+    与 <methodname>Yac::get</methodname> 不同，
+    属性语法无法区分存储的 &null; 和键不存在，并且只支持单键操作。
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><methodname>Yac::__get</methodname> 示例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$yac = new Yac();
+$yac->set("foo", "bar");
+
+var_dump($yac->foo);       // string(3) "bar"
+var_dump($yac->missing);   // NULL
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>Yac::get</methodname></member>
+    <member><methodname>Yac::__set</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/yac/yac/info.xml
+++ b/reference/yac/yac/info.xml
@@ -1,0 +1,187 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: Laruence Status: ready -->
+
+<refentry xml:id="yac.info" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Yac::info</refname>
+  <refpurpose>获取缓存状态</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>array</type><methodname>Yac::info</methodname>
+   <void />
+  </methodsynopsis>
+  <simpara>
+   获取缓存系统的状态。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   返回一个包含以下键的 <type>array</type>：
+  </simpara>
+  <variablelist>
+   <varlistentry>
+    <term><literal>memory_size</literal></term>
+    <listitem><simpara>
+     已使用的共享内存总量，单位为字节：槽位表加上值块。
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>slots_memory_size</literal></term>
+    <listitem><simpara>
+     为哈希槽位表预留的内存，单位为字节。
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>values_memory_size</literal></term>
+    <listitem><simpara>
+     为存储的值预留的内存，单位为字节。
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>segment_size</literal></term>
+    <listitem><simpara>
+     单个值内存段的大小，单位为字节。
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>segment_num</literal></term>
+    <listitem><simpara>
+     值内存段的数量。
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>miss</literal></term>
+    <listitem><simpara>
+     缓存未命中次数：查找时没有找到条目或条目已过期。
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>hits</literal></term>
+    <listitem><simpara>
+     缓存命中次数：成功找到条目的查找次数。
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>fails</literal></term>
+    <listitem><simpara>
+     存储失败次数：因无法分配值块而失败的存储次数。
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>kicks</literal></term>
+    <listitem><simpara>
+     驱逐次数：因候选槽位探测路径已满而不得不驱逐已有条目的次数。
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>recycles</literal></term>
+    <listitem><simpara>
+     分配器到达段末尾后回绕到段开头的次数。
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>start_time</literal></term>
+    <listitem><simpara>
+     共享内存缓存初始化时的 Unix 时间戳。
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>slots_size</literal></term>
+    <listitem><simpara>
+     哈希槽位的总数。
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>slots_used</literal></term>
+    <listitem><simpara>
+     当前已被占用的哈希槽位数。
+    </simpara></listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><methodname>Yac::info</methodname> 示例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$yac = new Yac();
+$yac->set("foo", "bar");
+
+print_r($yac->info());
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+Array
+(
+    [memory_size] => 46137344
+    [slots_memory_size] => 4194304
+    [values_memory_size] => 41943040
+    [segment_size] => 4194304
+    [segment_num] => 10
+    [miss] => 0
+    [hits] => 0
+    [fails] => 0
+    [kicks] => 0
+    [recycles] => 0
+    [start_time] => 1725955200
+    [slots_size] => 32768
+    [slots_used] => 1
+)
+]]>
+   </screen>
+   <simpara>
+    命中率可以按 <literal>hits / (hits + miss)</literal> 计算；
+    持续增长的 <literal>kicks</literal> 或 <literal>fails</literal>
+    计数器表明缓存正处于内存压力之下。
+   </simpara>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>Yac::dump</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/yac/yac/set.xml
+++ b/reference/yac/yac/set.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: Laruence Status: ready -->
+
+<refentry xml:id="yac.set" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Yac::set</refname>
+  <refpurpose>向缓存中存储一个值</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>bool</type><methodname>Yac::set</methodname>
+   <methodparam><type class="union"><type>string</type><type>array</type></type><parameter>keys</parameter></methodparam>
+   <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>ttl</parameter><initializer>0</initializer></methodparam>
+  </methodsynopsis>
+  <methodsynopsis>
+   <modifier>public</modifier> <type>bool</type><methodname>Yac::set</methodname>
+   <methodparam><type>array</type><parameter>values</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>ttl</parameter><initializer>0</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   向缓存中存储一个值。如果键已存在，
+   则覆盖已有条目，无论其是否已过期。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>keys</parameter></term>
+    <listitem>
+     <simpara>
+      <type>string</type> 类型的键，或者一个由
+      <literal>key =&gt; value</literal> 键值对组成的
+      <type>array</type>，一次调用存储多个条目。
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>value</parameter></term>
+    <listitem>
+     <simpara>
+      要存储的值。除 <type>resource</type> 外的所有 PHP 类型都可以存储。
+      仅在单键形式下使用；当 <parameter>keys</parameter> 是数组时，
+      该参数位置实际上是可选的 <parameter>ttl</parameter>。
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>ttl</parameter></term>
+    <listitem>
+     <simpara>
+      生存时间，单位为秒。<literal>0</literal> 表示条目永不因时间过期。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   成功时返回 &true;，失败时返回 &false;。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><methodname>Yac::set</methodname> 示例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$yac = new Yac();
+
+$yac->set("foo", "bar");                    // 存储单个值
+$yac->set("foo", "baz");                    // 覆盖已有条目
+
+// ttl 以秒为单位：该条目 5 秒后过期
+$yac->set("short-lived", "value", 5);
+sleep(6);
+var_dump($yac->get("short-lived"));        // bool(false)：已过期
+
+// 一次调用存储多个键值对
+$yac->set(array("a" => 1, "b" => 2));
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>Yac::add</methodname></member>
+    <member><methodname>Yac::get</methodname></member>
+    <member><methodname>Yac::__set</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/yac/yac/setter.xml
+++ b/reference/yac/yac/setter.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: Laruence Status: ready -->
+
+<refentry xml:id="yac.setter" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Yac::__set</refname>
+  <refpurpose>以属性语法存储一个值</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>mixed</type><methodname>Yac::__set</methodname>
+   <methodparam><type>string</type><parameter>key</parameter></methodparam>
+   <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   向缓存中存储一个值，写入 <classname>Yac</classname> 实例的属性时被调用：
+   <literal>$yac->foo = "bar"</literal> 等价于
+   <literal>$yac->set("foo", "bar")</literal>，且不带 ttl。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>key</parameter></term>
+    <listitem>
+     <simpara>
+      属性名，被用作缓存键。
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>value</parameter></term>
+    <listitem>
+     <simpara>
+      要存储的值。除 <type>resource</type> 外的所有 PHP 类型都可以存储。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   返回存储的值。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><methodname>Yac::__set</methodname> 示例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$yac = new Yac();
+
+$yac->foo = "bar";          // 存储时不带 ttl
+var_dump($yac->get("foo")); // string(3) "bar"
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>Yac::set</methodname></member>
+    <member><methodname>Yac::__get</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
## 概述

对照 doc-en 的 `yac-docs-revision` 分支（commit b2bb7d0），新增 Yac 扩展文档的中文翻译，共 15 个 XML 文件：

- **顶层页**：book（扩展简介，含无锁语义与适用边界说明）、setup（需求、安装、资源）、ini（7 个运行时配置项）、constants（预定义常量）
- **类页**：yac.xml（Yac 类）
- **方法页 ×10**：construct、add、set、get、getter、setter、delete、flush、info、dump（签名、参数、返回值、示例、See Also 均已翻译）

## 未翻译的文件及原因

- `versions.xml`：带 `<?do-not-translate?>` 指令，由脚本自动维护
- `configure.xml`：在 doc-en 中未被任何实体引用（孤儿文件，英文手册中不渲染）

## 说明

- 每个文件头部已标注 `EN-Revision`，便于追踪上游变更
- 翻译源是 doc-en 中修订过的版本：方法签名已对照扩展源码修正（如 `Yac::get` 移除了不存在的 `&$cas` 参数、`Yac::delete` 的 `ttl` 参数实为 `delay`），并补充了可运行示例

## 校验

- [x] doc-base `configure.php --with-lang=zh` 校验通过
- [x] phd 本地渲染抽查通过（签名、版本条、See Also 链接、setup 子页面均正常）