### PR TITLE
新增 Yaconf 扩展文档的中文翻译

### DIFF
--- a/reference/yaconf/book.xml
+++ b/reference/yaconf/book.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 3b052562d228be18fa6dce221df7e375469fb7ad Maintainer: laruence Status: ready -->
+
+<book xml:id="book.yaconf" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
+ <title>Yaconf</title>
+ <titleabbrev>Yaconf</titleabbrev>
+
+ <preface xml:id="intro.yaconf">
+  &reftitle.intro;
+  <simpara>
+   <literal>Yet Another Configurations Container</literal>（又一个配置容器，
+   简称 <acronym>Yaconf</acronym>）是一个配置容器。它在 PHP 启动时解析
+   <literal>INI</literal> 文件，并将解析结果常驻保存在内存中，贯穿 PHP
+   的整个生命周期。因此每一次读取配置都是一次快速的哈希表查找，
+   既没有文件 I/O，也不需要每个请求重新解析。
+  </simpara>
+  <simpara>
+   Yaconf 把所有配置以驻留字符串（interned string）或不可变数组的形式存储。
+   它们不参与引用计数，所以从 Yaconf 读取配置几乎是零拷贝的。
+   从 Yaconf 1.2.0 起，解析后的整棵配置树还会被进一步压缩到一块连续的
+   内存中，既降低了内存开销，也提升了缓存局部性。
+  </simpara>
+  <simpara>
+   解析后的配置保存在持久内存中，所有 PHP-FPM worker 通过写时复制
+   （copy-on-write）共享这份数据：只要配置文件没有变化，无论有多少个
+   worker，它们共享的都是同一份物理内存页。
+  </simpara>
+  <simpara>
+   Yaconf 支持 INI 文件中的 section（节）以及节继承。在非 ZTS 构建下，
+   它还会在文件变更时自动重新加载；在 ZTS（线程安全）构建下，
+   配置只在启动时加载一次，变更后需要重启 PHP 才能生效。
+  </simpara>
+  <simpara>
+   从 Yaconf 1.2.0 起，配置目录下的子目录会被递归加载（最多 16 层深），
+   子目录名作为一级键参与寻址：例如
+   <literal>Yaconf::get("users.database.master")</literal> 读取的是
+   <filename>users/</filename> 子目录下 <filename>database.ini</filename>
+   文件里的 <literal>master</literal> 键。
+  </simpara>
+  <simpara>
+   把敏感配置放在 Web 目录之外，也可以缩小攻击面。如果配置文件放在
+   Web 根目录下，攻击者就可能拿到它们，比如通过文件泄露漏洞。
+   而使用 Yaconf，可以把 <filename>.ini</filename> 文件放在只有
+   root 可读的目录里，例如 <filename>/etc/yaconf</filename>：
+   PHP-FPM master 进程在服务启动时加载配置，而实际处理 Web 请求的
+   worker 进程以普通用户身份运行，既不需要、也不会被授予对该目录的
+   访问权限。
+  </simpara>
+  <simpara>
+   Yaconf 需要 PHP 7.0 及以上版本。
+  </simpara>
+ </preface>
+
+ &reference.yaconf.setup;
+ &reference.yaconf.yaconf;
+
+</book>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/yaconf/configure.xml
+++ b/reference/yaconf/configure.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 9cfadc46e7d5a27ae5cc17430f3aa5fc5dc27a04 Maintainer: laruence Status: ready -->
+
+<section xml:id="yaconf.installation" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ &reftitle.install;
+
+ <para>
+  &pecl.info;
+  <link xlink:href="&url.pecl.package;yaconf">&url.pecl.package;yaconf</link>
+ </para>
+
+
+</section>
+
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/yaconf/ini.xml
+++ b/reference/yaconf/ini.xml
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 3b052562d228be18fa6dce221df7e375469fb7ad Maintainer: laruence Status: ready -->
+
+<section xml:id="yaconf.configuration" xmlns="http://docbook.org/ns/docbook">
+ &reftitle.runtime;
+ &extension.runtime;
+ <para>
+  <table>
+   <title>Yaconf &ConfigureOptions;</title>
+   <tgroup cols="4">
+    <thead>
+     <row>
+      <entry>&Name;</entry>
+      <entry>&Default;</entry>
+      <entry>&Changeable;</entry>
+      <entry>&Changelog;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry><link linkend="ini.yaconf.directory">yaconf.directory</link></entry>
+      <entry><literal>""</literal></entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
+      <entry><!-- leave empty, this will be filled by an automatic script --></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.yaconf.check-delay">yaconf.check_delay</link></entry>
+      <entry><literal>300</literal></entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
+      <entry><!-- leave empty, this will be filled by an automatic script --></entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </table>
+ </para>
+
+ &ini.descriptions.title;
+
+ <para>
+  <variablelist>
+   <varlistentry xml:id="ini.yaconf.directory">
+     <term>
+      <parameter>yaconf.directory</parameter>
+      <type>string</type>
+     </term>
+     <listitem>
+      <simpara>
+       存放所有 INI 配置文件的目录。只有扩展名为
+       <filename>.ini</filename> 的文件会被加载。
+       子目录会被递归加载（最多 16 层深），每一级子目录都作为一级键
+       参与寻址：例如放在 <filename>users/</filename> 子目录下的
+       <filename>database.ini</filename> 文件，通过
+       <literal>"users.database"</literal> 访问。该特性自 Yaconf 1.2.0
+       起提供；在此之前，只有直接位于该目录下的文件会被加载。
+      </simpara>
+      <simpara>
+       下面的示例假定在配置的目录中放置了如下
+       <filename>database.ini</filename>，以及一个存放各功能开关设置的
+       <filename>features.ini</filename>。
+      </simpara>
+      <example>
+       <title>INI 文件语法</title>
+       <programlisting role="ini">
+<![CDATA[
+; database.ini
+name=production                        ; scalar value
+version=PHP_VERSION                    ; PHP constants are resolved
+connection_string=${DATABASE_URL}      ; environment variables are resolved
+options.max_connections=50             ; nested hash key
+options.timeout=30
+
+; array entries, both notations are equivalent
+replicas.0=replica-1.example.com
+replicas[]=replica-2.example.com
+]]>
+       </programlisting>
+      </example>
+      <example>
+       <title>INI section 示例</title>
+       <programlisting role="ini">
+<![CDATA[
+; features.ini
+[default]
+cache_enabled=on
+rate_limit=100
+
+; the "premium" section inherits every key from "default" and
+; overrides the ones it redefines
+[premium:default]
+rate_limit=1000
+]]>
+       </programlisting>
+      </example>
+     </listitem>
+   </varlistentry>
+   <varlistentry xml:id="ini.yaconf.check-delay">
+     <term>
+      <parameter>yaconf.check_delay</parameter>
+      <type>int</type>
+     </term>
+     <listitem>
+      <simpara>
+       Yaconf 检查已加载的 INI 文件是否发生变更、并重新加载变更文件的时间间隔，
+       单位为秒（通过比较目录的修改时间来检测变更）。将其设置为
+       <literal>0</literal> 时，Yaconf 会在每个请求时都进行检查。
+      </simpara>
+      <note>
+       <simpara>
+        该配置项只在非 ZTS 构建中注册。在 ZTS（线程安全）构建中，
+        配置仅在启动时加载，不支持自动重新加载；修改后需要重启 PHP
+        才能生效。
+       </simpara>
+      </note>
+     </listitem>
+   </varlistentry>
+  </variablelist>
+ </para>
+</section>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/yaconf/setup.xml
+++ b/reference/yaconf/setup.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 3b052562d228be18fa6dce221df7e375469fb7ad Maintainer: laruence Status: ready -->
+
+<chapter xml:id="yaconf.setup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ &reftitle.setup;
+
+ <section xml:id="yaconf.requirements">
+  &reftitle.required;
+  <para>
+   Yaconf 需要 PHP 7.0 及以上版本。
+  </para>
+ </section>
+
+ <section xml:id="yaconf.installation">
+  &reftitle.install;
+  <simpara>
+   Yaconf 有三种安装方式：通过 PECL 安装、通过 PIE 安装，
+   或者从源码编译。
+  </simpara>
+  <para>
+   &pecl.moved;
+  </para>
+  <para>
+   &pecl.info;
+   <link xlink:href="&url.pecl.package;yaconf">&url.pecl.package;yaconf</link>.
+  </para>
+  <para>
+   &pecl.windows.download.avail;
+  </para>
+  <example>
+   <title>使用 PECL 安装 Yaconf</title>
+   <programlisting role="shell">
+<![CDATA[
+pecl install yaconf
+]]>
+   </programlisting>
+  </example>
+  <simpara>
+   从 Yaconf 1.2.0 起，还可以使用扩展安装器 &link.pie;
+   （PHP Installer for Extensions）来安装，在命令行中执行：
+  </simpara>
+  <example>
+   <title>使用 PIE 安装 Yaconf</title>
+   <programlisting role="shell">
+<![CDATA[
+pie install laruence/yaconf
+]]>
+   </programlisting>
+  </example>
+  <simpara>
+   源码托管在
+   <link xlink:href="&url.git.hub;laruence/yaconf">GitHub</link>
+   上。如需从源码编译安装，请在命令行中执行以下命令，
+   并将路径替换为本地 PHP 安装的实际路径：
+  </simpara>
+  <example>
+   <title>从源码编译 Yaconf</title>
+   <programlisting role="shell">
+<![CDATA[
+/path/to/phpize
+./configure --with-php-config=/path/to/php-config
+make && make install
+]]>
+   </programlisting>
+  </example>
+ </section>
+
+ &reference.yaconf.ini;
+
+ <section xml:id="yaconf.resources">
+  &reftitle.resources;
+  <para>
+
+  </para>
+ </section>
+
+</chapter>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/yaconf/versions.xml
+++ b/reference/yaconf/versions.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?do-not-translate?>
+<!-- EN-Revision: 3b052562d228be18fa6dce221df7e375469fb7ad Maintainer: laruence Status: ready -->
+
+<versions>
+  <!-- Classes and Methods -->
+
+ <function name='yaconf' from='PECL yaconf &gt;= 1.0.0'/>
+ <function name='yaconf::get' from='PECL yaconf &gt;= 1.0.0'/>
+ <function name='yaconf::has' from='PECL yaconf &gt;= 1.0.0'/>
+ <function name='yaconf::__debug_info' from='PECL yaconf &gt;= 1.1.0'/>
+</versions>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/yaconf/yaconf.xml
+++ b/reference/yaconf/yaconf.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: laruence Status: ready -->
+
+<reference xml:id="class.yaconf" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+
+ <title>Yaconf 类</title>
+ <titleabbrev>Yaconf</titleabbrev>
+
+ <partintro>
+
+<!-- {{{ Yaconf intro -->
+  <section xml:id="yaconf.intro">
+   &reftitle.intro;
+   <simpara>
+    Yaconf 是一个配置容器。它解析 INI 文件，
+    并在 PHP 启动时将解析结果保存在 PHP 中，
+    这些结果的生命周期贯穿整个 PHP 进程。
+   </simpara>
+  </section>
+<!-- }}} -->
+
+  <section xml:id="yaconf.synopsis">
+   &reftitle.classsynopsis;
+
+<!-- {{{ Synopsis -->
+   <classsynopsis>
+    <ooclass><classname>Yaconf</classname></ooclass>
+
+<!-- {{{ Class synopsis -->
+    <classsynopsisinfo>
+     <ooclass>
+      <classname>Yaconf</classname>
+     </ooclass>
+    </classsynopsisinfo>
+<!-- }}} -->
+
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yaconf')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
+   </classsynopsis>
+<!-- }}} -->
+
+  </section>
+
+ </partintro>
+
+ &reference.yaconf.entities.yaconf;
+
+</reference>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/yaconf/yaconf/debuginfo.xml
+++ b/reference/yaconf/yaconf/debuginfo.xml
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 3b052562d228be18fa6dce221df7e375469fb7ad Maintainer: laruence Status: ready -->
+
+<refentry xml:id="yaconf.debug-info" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Yaconf::__debug_info</refname>
+  <refpurpose>查看某个配置值的存储方式</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <modifier>static</modifier> <type class="union"><type>array</type><type>null</type></type><methodname>Yaconf::__debug_info</methodname>
+   <methodparam><type>string</type><parameter>name</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   返回以 <parameter>name</parameter>
+   该值在内存中的地址，以及该值是否仍然存放在 Yaconf
+   压缩后的存储块中。
+  </simpara>
+  <warning>
+   <simpara>
+    该方法存在的唯一目的是供 Yaconf 自身的测试套件使用，
+    测试用它来验证扩展是否工作正常。请勿在生产代码中使用它，
+    也不要依赖其输出格式：返回的数组可能随时变化。
+   </simpara>
+  </warning>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>name</parameter></term>
+    <listitem>
+     <simpara>
+      要查看的配置名，使用与 <methodname>Yaconf::get</methodname>
+      相同的点号记法。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   当配置存在时，返回一个包含四个元素的 <type>array</type>；
+   否则返回 &null;：
+  </simpara>
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     <literal>key</literal> —— 被查找的配置名。
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <literal>address</literal> —— 该值在内存中的地址。
+     配置值以驻留字符串（interned string）或不可变数组的形式存储，
+     因此在配置被重新加载之前，该地址保持不变。
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <literal>val</literal> —— 存储的值本身。
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <literal>changed</literal> —— 当该值的数据仍存放在压缩存储块内时
+     为 &false;，表示操作系统尚未复制过该内存页（写时复制仍然有效）；
+     当该值被重新分配到存储块之外时为 &true;。
+    </simpara>
+   </listitem>
+  </itemizedlist>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><methodname>Yaconf::__debug_info</methodname> 示例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+// 假设 app.ini 中包含 name="shop"
+var_dump(Yaconf::__debug_info("app.name"));
+/*
+array(4) {
+  ["key"]=>
+  string(8) "app.name"
+  ["address"]=>
+  string(14) "0x7f8b1c0a3d20"
+  ["val"]=>
+  string(4) "shop"
+  ["changed"]=>
+  bool(false)
+}
+*/
+
+var_dump(Yaconf::__debug_info("app.missing")); // NULL
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>Yaconf::get</methodname></member>
+    <member><methodname>Yaconf::has</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/yaconf/yaconf/get.xml
+++ b/reference/yaconf/yaconf/get.xml
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 3b052562d228be18fa6dce221df7e375469fb7ad Maintainer: laruence Status: ready -->
+
+<refentry xml:id="yaconf.get" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Yaconf::get</refname>
+  <refpurpose>按名称读取一个配置值</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <modifier>static</modifier> <type>mixed</type><methodname>Yaconf::get</methodname>
+   <methodparam><type>string</type><parameter>name</parameter></methodparam>
+   <methodparam choice="opt"><type>mixed</type><parameter>default</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   读取以 <parameter>name</parameter>
+   形式寻址，逐层定位嵌套的键：例如 <literal>"app"</literal>
+   中某个键的值。自 Yaconf 1.2.0 起，还支持
+   <literal>"users.database.master"</literal>
+   子目录下的 <filename>database.ini</filename> 文件中的键。
+   点号记法最多支持 64 层嵌套。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>name</parameter></term>
+    <listitem>
+     <simpara>
+      要查找的配置名。使用点号记法逐层定位嵌套的键，例如
+      <literal>"app.name"</literal>
+      <literal>"users.database.master"</literal>
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>default</parameter></term>
+    <listitem>
+     <simpara>
+      当 <parameter>name</parameter>
+      时返回该值。未指定时返回 &null;。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   当 <parameter>name</parameter>
+   <type>array</type>；否则返回 <parameter>default</parameter>
+   参数，则返回 &null;）。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <simpara>
+   下面的示例假定在 <literal>yaconf.directory</literal> 配置的目录中
+   放置了以下两个文件。
+  </simpara>
+  <programlisting role="ini">
+<![CDATA[
+; app.ini
+name="shop"                     ; scalar value
+debug=0                         ; number
+features[]="checkout"           ; array entries, both notations
+features.1="wishlist"
+]]>
+  </programlisting>
+  <programlisting role="ini">
+<![CDATA[
+; users/database.ini, in a sub-directory (Yaconf 1.2.0+)
+master="192.168.0.10"
+replica="192.168.0.20"
+]]>
+  </programlisting>
+  <example>
+   <title><methodname>Yaconf::get</methodname> 示例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+// 读取整个解析后的文件，返回数组
+var_dump(Yaconf::get("app"));
+
+// 点号记法逐层访问嵌套的键
+var_dump(Yaconf::get("app.name"));           // string(4) "shop"
+var_dump(Yaconf::get("app.features.1"));     // string(8) "wishlist"
+
+// 1.2.0 起：子目录中的文件以目录名作为命名空间
+var_dump(Yaconf::get("users.database.master")); // string(12) "192.168.0.10"
+
+// 键不存在时返回默认值
+var_dump(Yaconf::get("app.missing"));             // NULL
+var_dump(Yaconf::get("app.missing", "fallback")); // string(8) "fallback"
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>Yaconf::has</methodname></member>
+    <member><methodname>Yaconf::__debug_info</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/yaconf/yaconf/has.xml
+++ b/reference/yaconf/yaconf/has.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 3b052562d228be18fa6dce221df7e375469fb7ad Maintainer: laruence Status: ready -->
+
+<refentry xml:id="yaconf.has" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Yaconf::has</refname>
+  <refpurpose>检查某个配置值是否存在</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <modifier>static</modifier> <type>bool</type><methodname>Yaconf::has</methodname>
+   <methodparam><type>string</type><parameter>name</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   判断在 <parameter>name</parameter>
+   使用与 <methodname>Yaconf::get</methodname> 相同的点号记法：
+   例如 <literal>"app.name"</literal>
+   还可以用 <literal>"users.database.master"</literal>
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>name</parameter></term>
+    <listitem>
+     <simpara>
+      要查找的配置名。使用点号记法逐层定位嵌套的键，例如
+      <literal>"app.name"</literal>
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   如果在 <parameter>name</parameter>
+   &false;。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <simpara>
+   下面的示例假定在 <literal>yaconf.directory</literal> 配置的目录中
+   放置了一个 <filename>app.ini</filename>，其中包含
+   <literal>name="shop"</literal> 和 <literal>debug=0</literal> 两个键。
+  </simpara>
+  <example>
+   <title><methodname>Yaconf::has</methodname> 示例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+var_dump(Yaconf::has("app.name"));     // bool(true)
+var_dump(Yaconf::has("app.missing"));  // bool(false)
+
+// 可用于区分"存了空值"和"键不存在"：
+// 这两种情况下 Yaconf::get() 都会返回同一个默认值
+if (Yaconf::has("app.debug")) {
+    $debug = (bool) Yaconf::get("app.debug");
+}
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>Yaconf::get</methodname></member>
+    <member><methodname>Yaconf::__debug_info</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
## 概要

新增 Yaconf 扩展（PECL）的完整中文翻译，共 9 个文件，对照 doc-en EN-Revision `5ae869b7`（yaconf 修订 PR php/doc-en#5801 合入后的版本）：

- `reference/yaconf/book.xml` — 简介（零拷贝/驻留字符串、COW 共享、INI section 继承、子目录递归、安全边界）
- `reference/yaconf/setup.xml` — 安装（PECL / PIE / 源码编译三种方式）
- `reference/yaconf/ini.xml` — `yaconf.directory`、`yaconf.check_delay` 配置项及 INI 语法示例
- `reference/yaconf/configure.xml`、`yaconf.xml` — 编译配置与类摘要
- `reference/yaconf/versions.xml` — 版本信息（do-not-translate，原样复制）
- `reference/yaconf/yaconf/` — `get`、`has`、`__debug_info` 三个方法页

## 已验证

- [x] `php doc-base/configure.php --with-lang=zh` 校验通过（exit 0）
- [x] 9 个文件全部通过 XML 良构检查
- [x] CI 同款 `check-structure.php` 结构镜像检查：`checked=8 divergent=0`
- [x] EN-Revision 已核实为 doc-en 上游对应文件的最新提交
- [x] phd partial 渲染 `book.yaconf` 成功，页面内容抽查无误