### PR TITLE
新增 Taint 扩展文档

### DIFF
--- a/reference/taint/book.xml
+++ b/reference/taint/book.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: befe2b9fbe37b0925498f336632742651386b151 Maintainer: laruence Status: ready -->
+
+<book xml:id="book.taint" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
+ <title>Taint</title>
+ <titleabbrev>Taint</titleabbrev>
+
+ <preface xml:id="intro.taint">
+  &reftitle.intro;
+  <simpara>
+   Taint 是一个污点追踪扩展，用于检测 XSS 代码（即被污染的字符串），
+   也可以用来发现 SQL 注入、命令注入、文件路径注入等类似漏洞。
+  </simpara>
+  <simpara>
+   开启 taint 后，来自用户输入 ——
+   <varname>$_GET</varname>、<varname>$_POST</varname>
+   和 <varname>$_COOKIE</varname> —— 的字符串会在请求开始时被标记为
+   已污染，并且该标记会随字符串操作一路传递。当一个被污染的字符串
+   到达危险的汇点（sink，如输出、SQL 查询、shell 命令、文件路径等）时，
+   taint 会在该处发出警告。完整的清单见
+   <link linkend="taint.detail">传播规则与被检查的汇点</link>。
+  </simpara>
+  <simpara>
+   Taint 是开发和审计工具，而不是运行时的防御手段：它只报告可能
+   存在的问题，既不会拦截也不会修改数据。它有意采用保守策略，宁可
+   多报，因此一次"干净"的运行只意味着"taint 没有发现任何污点"，
+   绝不等于"已证明安全"。不要在生产环境中开启它。
+  </simpara>
+  <example>
+   <title>Taint 示例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$a = trim($_GET['a']);
+
+$file_name = '/tmp/' . $a;
+$output    = "Welcome, {$a} !!!";
+$sql       = "SELECT * FROM users WHERE name = " . $a;
+
+echo $output;
+print $output;
+include $file_name;
+mysqli_query($link, $sql);
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+Warning: main() [echo]: Attempt to echo a string that might be tainted in /path/to/script.php on line 9
+
+Warning: main() [print]: Attempt to print a string that might be tainted in /path/to/script.php on line 10
+
+Warning: main() [include]: File path contains data that might be tainted in /path/to/script.php on line 11
+
+Warning: main() [mysqli_query]: SQL statement contains data that might be tainted in /path/to/script.php on line 12
+]]>
+   </screen>
+  </example>
+ </preface>
+
+ &reference.taint.setup;
+ &reference.taint.detail;
+ &reference.taint.reference;
+
+</book>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/taint/configure.xml
+++ b/reference/taint/configure.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: befe2b9fbe37b0925498f336632742651386b151 Maintainer: laruence Status: ready -->
+
+<section xml:id="taint.installation" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ &reftitle.install;
+
+ <simpara>
+  &pecl.info;
+  <link xlink:href="&url.pecl.package;taint">&url.pecl.package;taint</link>.
+ </simpara>
+
+ <simpara>
+  通过 <acronym>PECL</acronym> 安装：
+ </simpara>
+ <para>
+  <screen>
+<![CDATA[
+$ pecl install taint
+]]>
+  </screen>
+ </para>
+
+ <para>
+  源码托管在
+  <link xlink:href="&url.git.hub;laruence/taint">GitHub</link>
+  上。如需从源码编译安装该扩展：
+  <screen>
+<![CDATA[
+$ git clone https://github.com/laruence/taint.git
+$ cd taint
+$ phpize
+$ ./configure
+$ make
+$ sudo make install
+]]>
+  </screen>
+ </para>
+
+ <simpara>
+  然后在 &php.ini; 中添加
+  <literal>extension=taint.so</literal>（Windows 下为
+  <literal>extension=php_taint.dll</literal>）启用该扩展，并将
+  <link linkend="ini.taint.enable">taint.enable</link> 设置为
+  <literal>1</literal>。
+ </simpara>
+
+ <warning>
+  <simpara>
+   Taint 是开发和审计工具。不要在生产环境中启用它：
+   插桩会拖慢每个请求并禁用 OPcache JIT，
+   而且警告信息可能会把请求数据泄露到日志中。
+  </simpara>
+ </warning>
+</section>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/taint/detail.xml
+++ b/reference/taint/detail.xml
@@ -1,0 +1,291 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: befe2b9fbe37b0925498f336632742651386b151 Maintainer: laruence Status: ready -->
+
+<chapter xml:id="taint.detail" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <title>传播规则与被检查的汇点</title>
+
+ <section xml:id="taint.detail.basic">
+  <title>污点标记如何传播</title>
+  <simpara>
+   污点标记是存储于字符串本身上的一个比特位，而不是存储于持有它的
+   变量上。对被污染的字符串进行赋值、传参或其它形式的共享，标记都会
+   保留。字符串拼接和插值同样会传播标记：
+  </simpara>
+  <para>
+   <table>
+    <title>会传播污点标记的运算符</title>
+    <tgroup cols="1">
+     <tbody>
+      <row>
+       <entry><literal>=</literal>（赋值，包括 <literal>list()</literal> / <literal>数组解构</literal>）</entry>
+      </row>
+      <row>
+       <entry><literal>.</literal>（拼接）</entry>
+      </row>
+      <row>
+       <entry><literal>.=</literal>（拼接赋值）</entry>
+      </row>
+      <row>
+       <entry><literal>"{$var}"</literal>（字符串插值，包括 <literal>ROPE</literal> 快速路径）</entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </table>
+  </para>
+  <simpara>
+   此外，taint 还理解一组固定的字符串函数：只要相关的字符串参数被污染，
+   返回的字符串也会被标记为已污染。常规调用和 PHP 8.4+ 的 frameless
+   快速路径调用都在覆盖范围内。
+  </simpara>
+  <para>
+   <table>
+    <title>会传播污点标记的函数</title>
+    <tgroup cols="1">
+     <tbody>
+      <row>
+       <entry><function>trim</function>, <function>rtrim</function>, <function>ltrim</function></entry>
+      </row>
+      <row>
+       <entry><function>substr</function>, <function>strstr</function></entry>
+      </row>
+      <row>
+       <entry><function>str_replace</function>, <function>str_ireplace</function></entry>
+      </row>
+      <row>
+       <entry><function>str_pad</function>, <function>strtolower</function>, <function>strtoupper</function>, <function>strval</function></entry>
+      </row>
+      <row>
+       <entry><function>explode</function>（结果数组中的每一个元素）</entry>
+      </row>
+      <row>
+       <entry><function>implode</function>/<function>join</function>（分隔符被污染时，结果同样会被污染）</entry>
+      </row>
+      <row>
+       <entry><function>sprintf</function>, <function>vsprintf</function>（只有 <literal>%s</literal> 说明符会携带标记；<literal>sprintf("%d", $t)</literal> 返回的是干净字符串）</entry>
+      </row>
+      <row>
+       <entry><function>dirname</function>, <function>basename</function>, <function>pathinfo</function></entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </table>
+  </para>
+  <simpara>
+   任何 taint 没有显式理解的函数都会返回一个新的、不带标记的字符串 ——
+   包括 <function>htmlspecialchars</function>、<function>htmlentities</function>
+   或 <function>mysqli_real_escape_string</function> 这类转义函数。
+   这是有意为之：taint 宁可多报，也不会去判断某个值在特定输出场景下
+   是否<quote>安全</quote>。对于已经自行校验过的值，请用
+   <function>untaint</function> 清除标记。
+  </simpara>
+ </section>
+
+ <section xml:id="taint.detail.sinks">
+  <title>taint 在哪里发出警告</title>
+  <simpara>
+   当一个被污染的字符串到达下列汇点（sink）之一时，taint 会发出警告
+   （默认级别为 <constant>E_USER_WARNING</constant>；可通过
+   <link linkend="ini.taint.error-level">taint.error_level</link>
+   配置）。只有顶层的字符串参数会被检查；只是内容中包含被污染值的数组，
+   在 dump 时不会触发警告。
+  </simpara>
+  <para>
+   <table>
+    <title>输出类汇点</title>
+    <tgroup cols="2">
+     <thead>
+      <row><entry>汇点</entry><entry>检查的内容</entry></row>
+     </thead>
+     <tbody>
+      <row>
+       <entry><literal>echo</literal>、<literal>print</literal></entry>
+       <entry>被 echo / print 输出的表达式</entry>
+      </row>
+      <row>
+       <entry><function>printf</function>、<function>vprintf</function></entry>
+       <entry>格式串及其代入的各个值</entry>
+      </row>
+      <row>
+       <entry><function>print_r</function>、<function>var_dump</function>、<function>var_export</function></entry>
+       <entry>被 dump 的值（当它是字符串时）</entry>
+      </row>
+      <row>
+       <entry>带消息的 <literal>exit</literal>/<literal>die</literal></entry>
+       <entry>消息内容</entry>
+      </row>
+      <row>
+       <entry>写入 <literal>php://output</literal> 的 <function>file_put_contents</function>、<function>fwrite</function>、<function>fputs</function></entry>
+       <entry>被写入的数据</entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </table>
+  </para>
+  <para>
+   <table>
+    <title>文件系统类汇点</title>
+    <tgroup cols="2">
+     <thead>
+      <row><entry>汇点</entry><entry>检查的内容</entry></row>
+     </thead>
+     <tbody>
+      <row>
+       <entry><function>fopen</function>、<function>opendir</function>、<function>unlink</function></entry>
+       <entry>路径</entry>
+      </row>
+      <row>
+       <entry><function>file</function>、<function>readfile</function>、<function>file_get_contents</function>、<function>highlight_file</function>/<function>show_source</function></entry>
+       <entry>路径</entry>
+      </row>
+      <row>
+       <entry><function>copy</function>、<function>rename</function>、<function>move_uploaded_file</function></entry>
+       <entry>源路径和目标路径</entry>
+      </row>
+      <row>
+       <entry><function>mkdir</function>、<function>rmdir</function>、<function>touch</function></entry>
+       <entry>路径</entry>
+      </row>
+      <row>
+       <entry><literal>include</literal>、<literal>include_once</literal>、<literal>require</literal>、<literal>require_once</literal></entry>
+       <entry>文件路径</entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </table>
+  </para>
+  <para>
+   <table>
+    <title>SQL 类汇点</title>
+    <tgroup cols="2">
+     <thead>
+      <row><entry>汇点</entry><entry>检查的内容</entry></row>
+     </thead>
+     <tbody>
+      <row>
+       <entry><function>mysqli_query</function>、<function>mysqli_prepare</function>、<function>mysqli_real_query</function>、<function>mysqli_multi_query</function></entry>
+       <entry>查询字符串</entry>
+      </row>
+      <row>
+       <entry><function>mysql_query</function>、<function>sqlite_query</function>、<function>sqlite_single_query</function>、<function>oci_parse</function>、<function>pg_query</function>、<function>pg_send_query</function></entry>
+       <entry>查询字符串</entry>
+      </row>
+      <row>
+       <entry><methodname>mysqli::query</methodname>、<methodname>mysqli::prepare</methodname>、<methodname>mysqli::real_query</methodname>、<methodname>mysqli::multi_query</methodname></entry>
+       <entry>查询字符串</entry>
+      </row>
+      <row>
+       <entry><methodname>PDO::query</methodname>、<methodname>PDO::prepare</methodname>、<methodname>PDO::exec</methodname></entry>
+       <entry>查询字符串</entry>
+      </row>
+      <row>
+       <entry><methodname>SQLite3::query</methodname>、<methodname>SQLite3::prepare</methodname>、<methodname>SQLite3::exec</methodname>、<methodname>SQLiteDatabase::query</methodname>、<methodname>SQLiteDatabase::singleQuery</methodname></entry>
+       <entry>查询字符串</entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </table>
+  </para>
+  <para>
+   <table>
+    <title>命令执行类汇点</title>
+    <tgroup cols="2">
+     <thead>
+      <row><entry>汇点</entry><entry>检查的内容</entry></row>
+     </thead>
+     <tbody>
+      <row>
+       <entry><function>exec</function>、<function>system</function>、<function>passthru</function>、<function>shell_exec</function>（包括反引号运算符）</entry>
+       <entry>命令字符串</entry>
+      </row>
+      <row>
+       <entry><function>proc_open</function>、<function>popen</function></entry>
+       <entry>命令字符串</entry>
+      </row>
+      <row>
+       <entry><literal>eval</literal></entry>
+       <entry>被执行的代码</entry>
+      </row>
+      <row>
+       <entry>动态调用，如 <literal>$func()</literal>、<literal>$obj-&gt;$method()</literal>、<function>call_user_func</function>、数组形式的 callable</entry>
+       <entry>被解析的函数/方法/类名</entry>
+      </row>
+      <row>
+       <entry><function>preg_match</function>、<function>preg_match_all</function>、<function>preg_replace</function>、<function>preg_split</function>、<function>preg_grep</function>、<function>preg_replace_callback</function></entry>
+       <entry>pattern（以及 <function>preg_replace_callback</function> 的回调名）</entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </table>
+  </para>
+  <para>
+   <table>
+    <title>HTTP 头与 Cookie 类汇点</title>
+    <tgroup cols="2">
+     <thead>
+      <row><entry>汇点</entry><entry>检查的内容</entry></row>
+     </thead>
+     <tbody>
+      <row>
+       <entry><function>header</function></entry>
+       <entry>header 字符串</entry>
+      </row>
+      <row>
+       <entry><function>setcookie</function>、<function>setrawcookie</function></entry>
+       <entry>cookie 的名称和值</entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </table>
+  </para>
+  <para>
+   <table>
+    <title>其他汇点</title>
+    <tgroup cols="2">
+     <thead>
+      <row><entry>汇点</entry><entry>检查的内容</entry></row>
+     </thead>
+     <tbody>
+      <row>
+       <entry><function>unserialize</function></entry>
+       <entry>序列化字符串</entry>
+      </row>
+      <row>
+       <entry><function>mail</function></entry>
+       <entry>to、subject、additional_parameters 和 additional_headers（邮件正文属于内容，不检查）</entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </table>
+  </para>
+  <simpara>
+   警告的格式为
+   <literal>function_name() [sink]: message</literal>，其中
+   <literal>sink</literal> 指明被检查的操作（例如
+   <literal>echo</literal>、<literal>include</literal> 或函数名），
+   message 则描述发现的可疑污染内容。
+  </simpara>
+ </section>
+
+</chapter>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/taint/functions/is-tainted.xml
+++ b/reference/taint/functions/is-tainted.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: befe2b9fbe37b0925498f336632742651386b151 Maintainer: laruence Status: ready -->
+
+<refentry xml:id="function.is-tainted" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>is_tainted</refname>
+  <refpurpose>检查一个字符串是否被污染</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>is_tainted</methodname>
+   <methodparam><type>string</type><parameter>string</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   检查给定的值是否携带污点标记。只有字符串可能被污染，
+   其他任何类型都返回 &false;。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>string</parameter></term>
+    <listitem>
+     <simpara>
+      待检查的值。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   如果该值是被污染的字符串，返回 &true;，否则返回 &false;。
+   当 <link linkend="ini.taint.enable">taint.enable</link> 未开启时，
+   始终返回 &false;。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><function>is_tainted</function> 示例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$name = $_GET['name'] ?? 'world';
+var_dump(is_tainted($name));
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+bool(true)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>taint</function></member>
+    <member><function>untaint</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/taint/functions/taint.xml
+++ b/reference/taint/functions/taint.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: befe2b9fbe37b0925498f336632742651386b151 Maintainer: laruence Status: ready -->
+
+<refentry xml:id="function.taint" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>taint</refname>
+  <refpurpose>将字符串标记为已污染</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>taint</methodname>
+   <methodparam><type>string</type><parameter role="reference">string</parameter></methodparam>
+   <methodparam rep="repeat"><type>string</type><parameter role="reference">strings</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   手动把指定的字符串标记为已污染，效果如同它们来自用户输入。
+   变量以引用方式传入，但标记本身存储于字符串而非变量之上：
+   共享同一字符串的所有变量会同时变为已污染状态。
+  </simpara>
+  <simpara>
+   该函数主要用于测试，以及在 <link linkend="reserved.variables.get">$_GET</link>、
+   <link linkend="reserved.variables.post">$_POST</link>
+   和 <link linkend="reserved.variables.cookies">$_COOKIE</link>
+   超全局变量没有数据的 CLI 脚本中模拟用户输入。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>string</parameter></term>
+    <listitem>
+     <simpara>
+      持有待标记字符串的变量。
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>strings</parameter></term>
+    <listitem>
+     <simpara>
+      更多待标记的变量。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   始终返回 &true;。当
+   <link linkend="ini.taint.enable">taint.enable</link> 未开启时，
+   该函数不做任何事，但仍然返回 &true;。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><function>taint</function> 示例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$name = "world";
+taint($name);
+var_dump(is_tainted($name));
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+bool(true)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="notes">
+  &reftitle.notes;
+  <note>
+   <simpara>
+    只有非空字符串会被标记；持有其他类型或空字符串的变量会被静默忽略。
+   </simpara>
+  </note>
+  <note>
+   <simpara>
+    interned、persistent 和 permanent 字符串（字符串字面量、
+    opcache 共享的字符串）永远无法携带标记，会被静默跳过。
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>untaint</function></member>
+    <member><function>is_tainted</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/taint/functions/untaint.xml
+++ b/reference/taint/functions/untaint.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: befe2b9fbe37b0925498f336632742651386b151 Maintainer: laruence Status: ready -->
+
+<refentry xml:id="function.untaint" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>untaint</refname>
+  <refpurpose>清除字符串上的污点标记</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>untaint</methodname>
+   <methodparam><type>string</type><parameter role="reference">string</parameter></methodparam>
+   <methodparam rep="repeat"><type>string</type><parameter role="reference">strings</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   清除指定字符串上的污点标记。
+  </simpara>
+  <simpara>
+   标记存储于字符串本身而非变量之上，因此一次调用即可同时清除
+   所有共享同一字符串的变量上的标记。可用它来为已经自行校验过的值
+   放行，例如在严格的白名单检查之后。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>string</parameter></term>
+    <listitem>
+     <simpara>
+      持有待清除标记的字符串的变量。
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>strings</parameter></term>
+    <listitem>
+     <simpara>
+      更多待清除标记的变量。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   始终返回 &true;。当
+   <link linkend="ini.taint.enable">taint.enable</link> 未开启时，
+   该函数不做任何事，但仍然返回 &true;。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><function>untaint</function> 示例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$id = "42";
+taint($id);
+if (preg_match('/^\d+$/', $id)) {
+    // strictly validated as digits: safe to trust
+    untaint($id);
+}
+var_dump(is_tainted($id));
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+bool(false)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="notes">
+  &reftitle.notes;
+  <note>
+   <simpara>
+    只有字符串能携带标记；传入非字符串值时不做任何事。
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>taint</function></member>
+    <member><function>is_tainted</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/taint/ini.xml
+++ b/reference/taint/ini.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: befe2b9fbe37b0925498f336632742651386b151 Maintainer: laruence Status: ready -->
+
+<section xml:id="taint.configuration" xmlns="http://docbook.org/ns/docbook">
+ &reftitle.runtime;
+ &extension.runtime;
+ <para>
+  <table>
+   <title>Taint &ConfigureOptions;</title>
+   <tgroup cols="4">
+    <thead>
+     <row>
+      <entry>&Name;</entry>
+      <entry>&Default;</entry>
+      <entry>&Changeable;</entry>
+      <entry>&Changelog;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry><link linkend="ini.taint.enable">taint.enable</link></entry>
+      <entry>0</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
+      <entry><!-- leave empty, this will be filled by an automatic script --></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.taint.error-level">taint.error_level</link></entry>
+      <entry>512 (E_USER_WARNING)</entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry><!-- leave empty, this will be filled by an automatic script --></entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </table>
+ </para>
+
+ &ini.descriptions.title;
+
+ <para>
+  <variablelist>
+   <varlistentry xml:id="ini.taint.enable">
+     <term>
+      <parameter>taint.enable</parameter>
+      <type>bool</type>
+     </term>
+     <listitem>
+      <simpara>
+       总开关。开启后，taint 会挂接执行器（executor），并在请求开始时
+       把来自 <varname>$_GET</varname>、<varname>$_POST</varname>
+       和 <varname>$_COOKIE</varname> 的字符串标记为已污染。
+      </simpara>
+      <simpara>
+       这是一个仅能在 &php.ini; 中设置的指令：开启它需要重启进程，
+       因此不能按请求或按目录切换。
+      </simpara>
+      <note>
+       <simpara>
+        不要在生产环境中开启该指令：插桩会拖慢每个请求，
+        并且与 OPcache JIT 不兼容。
+       </simpara>
+      </note>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="ini.taint.error-level">
+     <term>
+      <parameter>taint.error_level</parameter>
+      <type>int</type>
+     </term>
+     <listitem>
+      <simpara>
+       taint 报告可疑污染字符串时使用的错误级别。
+       默认为 <constant>E_USER_WARNING</constant>（512）。
+      </simpara>
+      <simpara>
+       由于该指令是 <constant>INI_ALL</constant>，可以在运行时修改。
+       例如，在脚本中关闭 taint 警告：
+      </simpara>
+      <para>
+       <programlisting role="php">
+<![CDATA[
+<?php
+ini_set('taint.error_level', 0);
+?>
+]]>
+       </programlisting>
+      </para>
+     </listitem>
+    </varlistentry>
+  </variablelist>
+ </para>
+</section>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/taint/reference.xml
+++ b/reference/taint/reference.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: befe2b9fbe37b0925498f336632742651386b151 Maintainer: laruence Status: ready -->
+
+<reference xml:id="ref.taint" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <title>Taint &Functions;</title>
+
+ &reference.taint.entities.functions;
+
+</reference>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/taint/setup.xml
+++ b/reference/taint/setup.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: befe2b9fbe37b0925498f336632742651386b151 Maintainer: laruence Status: ready -->
+
+<chapter xml:id="taint.setup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ &reftitle.setup;
+
+ <section xml:id="taint.requirements">
+  &reftitle.required;
+  <simpara>
+   Taint 3.x 需要 PHP 8.0 及以上版本。PHP 7.x 请使用
+   taint 2.1.x 系列，PHP 5.x 请使用 taint 1.x 系列。
+  </simpara>
+ </section>
+
+ <!-- {{{ Installation -->
+ &reference.taint.configure;
+ <!-- }}} -->
+
+ <!-- {{{ Configuration -->
+ &reference.taint.ini;
+ <!-- }}} -->
+
+ <section xml:id="taint.resources">
+  &reftitle.resources;
+  <simpara>
+   Taint 不定义任何资源类型。污点标记本身存储于内部的
+   <literal>zend_string</literal> 结构中，而不是某种用户可见的资源。
+  </simpara>
+ </section>
+
+</chapter>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/taint/versions.xml
+++ b/reference/taint/versions.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?do-not-translate?>
+<!-- EN-Revision: c2149ab44867d36166d750d5d8730a2ca7dd61e2 Maintainer: laruence Status: ready -->
+
+<versions>
+ <!-- Functions -->
+ <function name='taint' from='PECL taint &gt;=0.1.0'/>
+ <function name='untaint' from='PECL taint &gt;=0.1.0'/>
+ <function name='is_tainted' from='PECL taint &gt;=0.1.0'/>
+</versions>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
## 概要

新增 Taint 扩展（PECL）的完整中文翻译，共 10 个文件，对照官方 `php/doc-en` EN-Revision `befe2b9fbe`（Revise the Taint extension documentation #5802）：

- `reference/taint/book.xml` — 简介（污点追踪原理、使用边界、示例）
- `reference/taint/setup.xml` — PHP 版本要求与资源说明
- `reference/taint/ini.xml` — `taint.enable`、`taint.error_level` 两个配置项
- `reference/taint/configure.xml` — PECL 安装与源码编译
- `reference/taint/detail.xml` — 传播规则与被检查的汇点（输出/文件系统/SQL/命令执行/HTTP 头与其他六类汇点表）
- `reference/taint/reference.xml`、`versions.xml` — 函数引用入口与版本信息（do-not-translate）
- `reference/taint/functions/` — `taint`、`untaint`、`is_tainted` 三个函数页

## 已验证

- [x] `php doc-base/configure.php --with-lang=zh` 校验通过（exit 0）
- [x] 10 个文件全部通过 XML 良构检查
- [x] CI 同款 `check-structure.php` 结构镜像检查：`checked=10 divergent=0`
- [x] EN-Revision 已核实为官方 `php/doc-en` 中对应文件的最新提交