### PR TITLE
新增 Yar 协议章节并同步更新 Yar 扩展中文翻译

### DIFF
--- a/reference/yar/book.xml
+++ b/reference/yar/book.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: mowangjuanzi Status: ready -->
+<!-- EN-Revision: 60ce1c5c7cc6d340191828de21f1d6b48cd83807 Maintainer: mowangjuanzi Status: ready -->
 <book xml:id="book.yar" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <?phpdoc extension-membership="pecl" ?>
  <title>Yet Another RPC Framework</title>
@@ -15,14 +15,16 @@
   <simpara>
    Yar 是一个原生 PHP 扩展，而不是用户态的库。它基于 HTTP、HTTPS 或 TCP
    使用紧凑的二进制协议，并内置三种打包器（<literal>php</literal>、<literal>json</literal>，以及在使用
-   <option role="configure">--enable-msgpack</option> 编译时的
-   <literal>msgpack</literal>），因此不需要额外的依赖包或代理进程。
+   <option role="configure">--enable-msgpack</option> 编译时可用的
+   <literal>msgpack</literal>），因此无需安装额外的依赖包或代理进程。
   </simpara>
   <simpara>
-   该协议与语言无关：目前已存在 C、Java 和 Lua 的兼容实现。
+   该协议与语言无关，任何语言都可以轻松实现与 Yar 服务的通信，
+   具体细节参见 <link linkend="yar.protocol">Yar 协议</link>。
   </simpara>
  </preface>
 
+ &reference.yar.protocol;
  &reference.yar.setup;
  &reference.yar.constants;
  &reference.yar.examples;

--- a/reference/yar/constants.xml
+++ b/reference/yar/constants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: mowangjuanzi Status: ready -->
+<!-- EN-Revision: 60ce1c5c7cc6d340191828de21f1d6b48cd83807 Maintainer: mowangjuanzi Status: ready -->
 <appendix xml:id="yar.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.constants;
  &extension.constants;
@@ -299,6 +299,19 @@
    <listitem>
     <simpara>
      远程服务在处理请求的过程中抛出了异常。
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-err-forbidden">
+   <term>
+    <constant>YAR_ERR_FORBIDDEN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     请求被服务器端的身份验证拒绝（参见
+     <link linkend="yar.protocol">Yar 协议头</link>的
+     <literal>provider</literal> 和 <literal>token</literal> 字段）。
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/yar/examples.xml
+++ b/reference/yar/examples.xml
@@ -1,16 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: mowangjuanzi Status: ready -->
+<!-- EN-Revision: 60ce1c5c7cc6d340191828de21f1d6b48cd83807 Maintainer: mowangjuanzi Status: ready -->
 <!-- CREDITS: Luffy -->
 <chapter xml:id="yar.examples" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.examples;
+ <simpara>
+  下面的示例演示了一个完整的服务：一个暴露若干算术方法的服务端、
+  一个调用它们的同步客户端、一个一次性发出多个并发调用的客户端，
+  以及一个通过 TCP 与服务器通信的客户端。
+ </simpara>
+
  <example>
   <title>Yar 服务端示例</title>
+  <simpara>
+   Yar 服务就是一个由 <classname>Yar_Server</classname>
+   包装的普通 PHP 类。对象的每一个公开方法都会成为一个 RPC
+   端点，而受保护方法、私有方法以及方法名以下划线开头的方法，
+   对客户端不可见。公开方法的文档注释会被收集起来，
+   显示在服务信息页面上。
+  </simpara>
+  <simpara>
+   RPC 请求以 HTTP POST 请求的形式到达，请求体携带 Yar 二进制协议
+   负载，因此这个脚本通常被映射为常规 Web 服务器上的一个 URI。
+  </simpara>
   <programlisting role="php">
 <![CDATA[
 <?php
 
-/* 假设这个页面可以通过 http://example.com/operator.php 访问 */
+/* 假设这个页面可以通过 http://api.example.com/operator.php 访问 */
 
 class Operator {
 
@@ -57,10 +74,12 @@ $server->handle();
  <example>
   <title>通过浏览器访问服务端（GET 请求）</title>
   <simpara>
-   当向服务地址发起 GET 请求时，Yar 会渲染一个信息页面，
+   当向服务地址发起 GET 请求时（例如直接在浏览器中打开它），
+   Yar 不会执行 RPC 调用，而是渲染一个信息页面，
    列出执行对象的每一个公开方法及其文档注释。
    该行为由
-   <link linkend="ini.yar.expose-info">yar.expose_info</link> 配置项控制。
+   <link linkend="ini.yar.expose-info">yar.expose_info</link>
+   配置项控制；当它关闭时，GET 请求将失败。
   </simpara>
   &example.outputs.similar;
   <mediaobject>
@@ -73,10 +92,22 @@ $server->handle();
 
  <example>
   <title>Yar 客户端示例</title>
+  <simpara>
+   <classname>Yar_Client</classname> 绑定到单一的服务地址。
+   在它上面调用任何未定义的方法，都会被透明地转换为同步
+   RPC 调用，远程方法用起来和本地方法一样；
+   <methodname>Yar_Client::call</methodname>
+   显式地按方法名做同样的事情。
+  </simpara>
+  <simpara>
+   受保护方法不会被暴露：调用它们会失败，并抛出错误码为
+   <constant>YAR_ERR_REQUEST</constant> 的
+   <exceptionname>Yar_Client_Exception</exceptionname>。
+  </simpara>
   <programlisting role="php">
 <![CDATA[
 <?php
-$client = new Yar_Client("http://example.com/operator.php");
+$client = new Yar_Client("http://api.example.com/operator.php");
 
 /* 直接调用 */
 var_dump($client->add(1, 2));
@@ -84,7 +115,7 @@ var_dump($client->add(1, 2));
 /* 通过 call() 调用 */
 var_dump($client->call("add", array(3, 2)));
 
-/* _add 无法被调用: 它不是公开方法 */
+/* _add 无法被调用：它不是公开方法 */
 var_dump($client->_add(1, 2));
 ?>
 ]]>
@@ -94,17 +125,33 @@ var_dump($client->_add(1, 2));
 <![CDATA[
 int(3)
 int(5)
-PHP Fatal error:  Uncaught Yar_Server_Request_Exception: call to undefined api Operator::_add() in *
+PHP Fatal error:  Uncaught Yar_Client_Exception: call to undefined api Operator::_add() in *
 ]]>
   </screen>
  </example>
 
  <example>
   <title>Yar 并发客户端示例</title>
+  <simpara>
+   <classname>Yar_Concurrent_Client</classname>
+   不是逐个调用服务，而是先注册多个调用，然后通过
+   <methodname>Yar_Concurrent_Client::loop</methodname>
+   一次性发出所有调用。响应按到达的顺序传递给回调函数，
+   而不是按调用注册的顺序。
+  </simpara>
+  <simpara>
+   在全部请求发送完毕后，回调函数会以 &null;
+   参数被调用一次，以便调用方知道没有更多请求等待发送；
+   下面的示例检查了这个通知。
+  </simpara>
   <programlisting role="php">
 <![CDATA[
 <?php
 function callback($ret, $callinfo) {
+    if ($callinfo == NULL) {
+        /* all requests are sent, waiting for the responses */
+        return;
+    }
     echo $callinfo['method'], " result: ", $ret, "\n";
 }
 
@@ -113,9 +160,9 @@ function error_callback($type, $error, $callinfo) {
 }
 
 /* 注册对远程服务的异步调用 */
-Yar_Concurrent_Client::call("http://example.com/operator.php", "add", array(1, 2), "callback");
-Yar_Concurrent_Client::call("http://example.com/operator.php", "sub", array(2, 1), "callback");
-Yar_Concurrent_Client::call("http://example.com/operator.php", "mul", array(2, 2), "callback");
+Yar_Concurrent_Client::call("http://api.example.com/operator.php", "add", array(1, 2), "callback");
+Yar_Concurrent_Client::call("http://api.example.com/operator.php", "sub", array(2, 1), "callback");
+Yar_Concurrent_Client::call("http://api.example.com/operator.php", "mul", array(2, 2), "callback");
 
 /* 发送所有请求并等待响应 */
 Yar_Concurrent_Client::loop("callback", "error_callback");
@@ -137,8 +184,9 @@ add result: 3
   <simpara>
    除了 HTTP 之外，<classname>Yar_Client</classname> 还可以
    通过 TCP 或 Unix socket 与兼容 Yar 协议的服务器通信，
-   例如一个由 Yar C 框架实现的服务。
-   远程服务器必须实现相同的 Yar 二进制协议。
+   例如一个由
+   <link xlink:href="&url.git.hub;laruence/yar-c">Yar C 框架</link>
+   实现的服务，它提供的二进制 Yar 协议与 PHP 服务端使用的相同。
   </simpara>
   <programlisting role="php">
 <![CDATA[

--- a/reference/yar/protocol.xml
+++ b/reference/yar/protocol.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 60ce1c5c7cc6d340191828de21f1d6b48cd83807 Maintainer: laruence Status: ready -->
+<!-- EN-Revision: 60ce1c5c7cc6d340191828de21f1d6b48cd83807 Maintainer: Laruence Status: ready -->
 <chapter xml:id="yar.protocol" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Yar 协议</title>
  <simpara>

--- a/reference/yar/protocol.xml
+++ b/reference/yar/protocol.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 60ce1c5c7cc6d340191828de21f1d6b48cd83807 Maintainer: laruence Status: ready -->
+<chapter xml:id="yar.protocol" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <title>Yar 协议</title>
+ <simpara>
+  Yar 不依赖 schema 或 IDL 文件：网络上传输的一切都是纯字节。
+  任何能够读写字节的语言都可以与 Yar 服务通信，完全不需要安装任何框架——
+  只需构造一个固定大小的二进制请求头和一个序列化后的请求体，
+  把它们发送到服务 URI，再解析响应即可。
+ </simpara>
+ <simpara>
+  一条消息由一个固定大小为 82 字节的头部和紧随其后的消息体组成。
+  头部的布局与下面的 C 结构体完全一致，紧凑排列、没有填充字节，
+  并按声明顺序逐个字段写入网络：
+ </simpara>
+ <programlisting role="c">
+<![CDATA[
+typedef struct _yar_header {
+    uint32_t       id;            /* transaction id */
+    uint16_t       version;       /* protocol version, currently always 0 */
+    uint32_t       magic_num;     /* must be 0x80DFEC60 */
+    uint32_t       reserved;
+    unsigned char  provider[32];  /* request from whom (authentication) */
+    unsigned char  token[32];     /* request token (authentication) */
+    uint32_t       body_len;      /* length of the whole body, including
+                                     the packager identifier */
+} __attribute__ ((packed)) yar_header_t;
+]]>
+ </programlisting>
+ <simpara>
+  其中 <literal>id</literal>、<literal>magic_num</literal>、<literal>reserved</literal>
+  和 <literal>body_len</literal> 字段以网络字节序（大端）存储；
+  其余字段是原始字节。
+ </simpara>
+ <simpara>
+  消息体以一个 8 字节的打包器标识符开头——<literal>PHP</literal>、<literal>JSON</literal>
+  或 <literal>MSGPACK</literal>，不足部分以零填充——用于告知接收方其余内容的编码方式，
+  其后是序列化内容本身。
+ </simpara>
+ <itemizedlist>
+  <listitem>
+   <simpara>
+    请求体解码后是一个数组，包含以下键：<literal>i</literal>（事务 id）、<literal>m</literal>
+    （被调用的方法）和 <literal>p</literal>（参数列表）。
+   </simpara>
+  </listitem>
+  <listitem>
+   <simpara>
+    响应体解码后是一个数组，包含以下键：<literal>i</literal>（事务 id）、<literal>s</literal>
+    （状态，取值为 <literal>YAR_ERR_*</literal> 常量之一）、<literal>r</literal>（返回值）、
+    <literal>o</literal>（服务方法产生的任何输出）以及 <literal>e</literal>
+    （调用失败时的错误或异常）。
+   </simpara>
+  </listitem>
+ </itemizedlist>
+ <simpara>
+  通过 HTTP 传输时，消息作为 POST 请求的正文发送，响应作为回复的正文到达；
+  通过 TCP 或 Unix socket 传输时，消息直接写入流中。
+ </simpara>
+ <example>
+  <title>在不安装扩展的情况下调用 Yar 服务</title>
+  <simpara>
+   下面这个独立脚本仅使用标准 socket，就为 <literal>php</literal>
+   打包器构造了一个有效的 Yar 请求，将其发送到服务 URI，
+   并输出解码后的响应。用
+   <link linkend="yar.examples">示例</link>中的
+   <classname>Operator</classname> 服务运行该脚本，输出为
+   <literal>int(3)</literal>。
+  </simpara>
+  <programlisting role="php">
+<![CDATA[
+<?php
+
+$uri = "http://api.example.com/operator.php";
+
+/* 1. the body: packager identifier + serialized request */
+$serialized = serialize(array("i" => 1, "m" => "add", "p" => array(1, 2)));
+$body = str_pad("PHP", 8, "\0") . $serialized;
+
+/* 2. the header: 82 bytes, multi-byte integers in network byte order */
+$header = pack("N", 1)                    /* id */
+        . pack("v", 0)                    /* version */
+        . pack("N", 0x80DFEC60)           /* magic number */
+        . pack("N", 0)                    /* reserved */
+        . str_pad("", 32, "\0")           /* provider */
+        . str_pad("", 32, "\0")           /* token */
+        . pack("N", strlen($body));       /* body length */
+
+/* 3. send it as the body of a POST request */
+$stream = stream_context_create(array("http" => array(
+    "method"  => "POST",
+    "header"  => "Content-Type: application/octet-stream\r\n",
+    "content" => $header . $body,
+)));
+$reply = file_get_contents($uri, false, $stream);
+
+/* 4. parse the reply: 82-byte header, then the response body */
+$response = unserialize(substr($reply, 82 + 8));
+var_dump($response["r"]);
+?>
+]]>
+  </programlisting>
+ </example>
+ <simpara>
+  一个更完整的纯 PHP 客户端实现位于
+  <link xlink:href="&url.git.hub;laruence/yar">Yar 源码仓库</link>的
+  <literal>tools/</literal> 目录中，它还会解码响应头，并支持并发调用。
+ </simpara>
+</chapter>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/yar/setup.xml
+++ b/reference/yar/setup.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: mowangjuanzi Status: ready -->
+<!-- EN-Revision: 60ce1c5c7cc6d340191828de21f1d6b48cd83807 Maintainer: mowangjuanzi Status: ready -->
 <!-- CREDITS: Luffy -->
 <chapter xml:id="yar.setup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.setup;
@@ -27,6 +27,9 @@
  <section xml:id="yar.installation">
   &reftitle.install;
   <simpara>
+   Yar 有三种安装方式：通过 PECL、通过 PIE，或从源码构建。
+  </simpara>
+  <simpara>
    &pecl.moved;
   </simpara>
   <simpara>
@@ -36,64 +39,97 @@
   <simpara>
    &pecl.windows.download.avail;
   </simpara>
-  <para>
-   源代码托管在
-   <link xlink:href="&url.git.hub;laruence/yar">GitHub</link> 上。从源码构建该扩展：
-   <screen>
+  <example>
+   <title>用 PECL 安装 Yar</title>
+   <programlisting role="shell">
 <![CDATA[
-$ git clone https://github.com/laruence/yar.git
-$ cd yar
-$ phpize
-$ ./configure
-$ make
-$ sudo make install
+pecl install yar
 ]]>
-   </screen>
-  </para>
-  <para>
-   可以使用以下 <literal>configure</literal> 选项：
-   <variablelist>
-    <varlistentry>
-     <term>
-      <option role="configure">--with-curl</option>
-     </term>
-     <listitem>
-      <simpara>
-       当 cURL 不在默认的 include 路径中时，
-       指定 cURL 的安装位置。
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>
-      <option role="configure">--enable-msgpack</option>
-     </term>
-     <listitem>
-      <simpara>
-       启用 <literal>msgpack</literal> 打包器，并将
-       <literal>msgpack</literal> 扩展作为可选依赖。当
-       Yar 使用该选项编译时，
-       <link linkend="ini.yar.packager">yar.packager</link> 的默认值变为
-       <literal>msgpack</literal>。
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>
-      <option role="configure">--enable-epoll</option>
-     </term>
-     <listitem>
-      <simpara>
-       使用 Linux <literal>epoll</literal> 代替
-       <literal>select()</literal> 进行 I/O 多路复用，自
-       Yar 2.1.2 起可用。在高并发场景下，该选项可以提升
-       <classname>Yar_Concurrent_Client</classname> 的性能。
-       它仅在 Linux 上生效；在其他平台上会被静默忽略。
-      </simpara>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+   </programlisting>
+  </example>
+  <simpara>
+   自 Yar 2.4.0 起，也可以使用 &link.pie;（PHP Installer for
+   Extensions，PHP 扩展安装器）安装本扩展。在命令行执行以下命令：
+  </simpara>
+  <example>
+   <title>用 PIE 安装 Yar</title>
+   <programlisting role="shell">
+<![CDATA[
+pie install laruence/yar
+]]>
+   </programlisting>
+  </example>
+  <simpara>
+   安装时可以同时启用 msgpack 打包器：
+  </simpara>
+  <example>
+   <title>用 PIE 安装 Yar 并启用 msgpack</title>
+   <programlisting role="shell">
+<![CDATA[
+pie install laruence/yar --enable-msgpack
+]]>
+   </programlisting>
+  </example>
+  <simpara>
+   源代码托管在
+   <link xlink:href="&url.git.hub;laruence/yar">GitHub</link> 上。
+   若要自源码构建该扩展，请在命令行执行以下命令，
+   并把其中的路径替换为本地 PHP 安装的实际路径：
+  </simpara>
+  <example>
+   <title>从源码构建 Yar</title>
+   <programlisting role="shell">
+<![CDATA[
+/path/to/phpize
+./configure --with-php-config=/path/to/php-config
+make && make install
+]]>
+   </programlisting>
+  </example>
+  <simpara>
+   可用的 <literal>configure</literal> 选项如下：
+  </simpara>
+  <variablelist>
+   <varlistentry>
+    <term>
+     <option role="configure">--with-curl</option>
+    </term>
+    <listitem>
+     <simpara>
+      当 cURL 不在默认的 include 路径中时，
+      指定 cURL 的安装位置。
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     <option role="configure">--enable-msgpack</option>
+    </term>
+    <listitem>
+     <simpara>
+      启用 <literal>msgpack</literal> 打包器，并将
+      <literal>msgpack</literal> 扩展作为可选依赖。当
+      Yar 使用该选项编译时，
+      <link linkend="ini.yar.packager">yar.packager</link> 的默认值变为
+      <literal>msgpack</literal>。
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     <option role="configure">--enable-epoll</option>
+    </term>
+    <listitem>
+     <simpara>
+      使用 Linux <literal>epoll</literal> 代替
+      <literal>select()</literal> 进行 I/O 多路复用，自
+      Yar 2.1.2 起可用。在高并发场景下，该选项可以提升
+      <classname>Yar_Concurrent_Client</classname> 的性能。
+      它仅在 Linux 上生效；在其他平台上会被静默忽略。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </section>
  <!-- }}} -->
 

--- a/reference/yar/yar-concurrent-client.xml
+++ b/reference/yar/yar-concurrent-client.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: mowangjuanzi Status: ready -->
+<!-- EN-Revision: 60ce1c5c7cc6d340191828de21f1d6b48cd83807 Maintainer: mowangjuanzi Status: ready -->
 <reference xml:id="class.yar-concurrent-client" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>Yar_Concurrent_Client 类</title>
@@ -18,9 +18,17 @@
     <methodname>Yar_Concurrent_Client::loop</methodname>
     统一并行发出。
    </simpara>
+   <simpara>
+    该类适用于需要多个远程调用结果的应用。只有互相独立——不依赖彼此结果——的调用才能这样批量发起；
+    当一个调用依赖另一个调用的结果时，两者只能串行执行。通过
+    <classname>Yar_Client</classname>
+    调用会一个接一个地发送，每次都要付出完整的往返时间；
+    而使用并发客户端时它们会同时发出，因此整体等待时间降为最慢单次调用的耗时。
+   </simpara>
    <note>
     <simpara>
-     并发调用仅支持 HTTP(S) 服务。
+     并发调用仅支持 HTTP(S) 服务。这些调用通过 curl 的 multi-handle
+     接口同时发出，TCP/Unix socket 传输方式没有提供该能力。
     </simpara>
    </note>
   </section>

--- a/reference/yar/yar-server.xml
+++ b/reference/yar/yar-server.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: mowangjuanzi Status: ready -->
+<!-- EN-Revision: 60ce1c5c7cc6d340191828de21f1d6b48cd83807 Maintainer: mowangjuanzi Status: ready -->
 <reference xml:id="class.yar-server" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>Yar_Server 类</title>
@@ -15,6 +15,11 @@
     包装一个对象，并将其所有公开方法作为远程服务对外暴露，
     通过 <methodname>Yar_Server::handle</methodname>
     以 HTTP 方式提供服务。
+   </simpara>
+   <simpara>
+    PHP 扩展只提供 HTTP 服务器。遵循同一 Yar 协议的 TCP 和
+    Unix socket 服务器由
+    <link xlink:href="&url.git.hub;laruence/yar-c">Yar C 框架</link>提供。
    </simpara>
   </section>
 <!-- }}} -->

--- a/reference/yar/yar_client/call.xml
+++ b/reference/yar/yar_client/call.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: mowangjuanzi Status: ready -->
+<!-- EN-Revision: 60ce1c5c7cc6d340191828de21f1d6b48cd83807 Maintainer: mowangjuanzi Status: ready -->
 <refentry xml:id="yar-client.call" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yar_Client::call</refname>
@@ -16,8 +16,8 @@
   </methodsynopsis>
   <simpara>
    对远程方法 <literal>method</literal> 发起一次 RPC 调用。
-   这与在 <classname>Yar_Client</classname> 对象上调用一个不存在的方法时发生的事情完全相同（参见
-   <methodname>Yar_Client::__call</methodname>）；
+   这与在 <classname>Yar_Client</classname> 对象上调用一个不存在的方法时发生的事情完全相同
+   （通过 PHP 的 <literal>__call</literal> 魔法方法）；
    <methodname>Yar_Client::call</methodname> 的存在只是为了让名字恰好叫
    <literal>call</literal> 或 <literal>__call</literal> 的远程方法仍然可以被调用。
   </simpara>
@@ -55,17 +55,50 @@
  <refsect1 role="errors">
   &reftitle.errors;
   <simpara>
-   如果服务器端不存在 <literal>call</literal> 方法，会抛出
-   <exceptionname>Yar_Server_Request_Exception</exceptionname> 异常。
-   各种失败情况及其对应的异常类的完整列表，参见
-   <methodname>Yar_Client::__call</methodname>。
+   当远程方法在服务器上不存在，或不是公开方法时，客户端会抛出错误码为
+   <constant>YAR_ERR_REQUEST</constant> 的
+   <exceptionname>Yar_Client_Exception</exceptionname>。
+   其他客户端侧的失败情况及其对应的异常类，参见
+   <link linkend="class.yar-client-exception">Yar_Client_Exception</link>。
   </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><methodname>Yar_Client::call</methodname> 示例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$client = new Yar_Client("http://api.example.com/operator.php");
+
+/* The usual way: invoke the remote method as if it were local.
+ * This is translated into call("add", array(1, 2)) behind the scenes. */
+var_dump($client->add(1, 2));
+
+/* Equivalent: call the method explicitly by name */
+var_dump($client->call("add", array(1, 2)));
+
+/* Needed only when the remote service literally exposes a method
+ * named call (or __call), which the magic __call cannot reach */
+var_dump($client->call("call", array($some_argument)));
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+int(3)
+int(3)
+...
+]]>
+   </screen>
+  </example>
  </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
-   <member><methodname>Yar_Client::__call</methodname></member>
    <member><methodname>Yar_Client::setOpt</methodname></member>
   </simplelist>
  </refsect1>

--- a/reference/yar/yar_client/construct.xml
+++ b/reference/yar/yar_client/construct.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: mowangjuanzi Status: ready -->
+<!-- EN-Revision: 60ce1c5c7cc6d340191828de21f1d6b48cd83807 Maintainer: mowangjuanzi Status: ready -->
 <refentry xml:id="yar-client.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yar_Client::__construct</refname>
@@ -70,10 +70,10 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$client = new Yar_Client("http://host/api/");
+$client = new Yar_Client("http://api.example.com/operator.php");
 
 /* 带选项创建 */
-$client = new Yar_Client("http://host/api/", [
+$client = new Yar_Client("http://api.example.com/operator.php", [
     YAR_OPT_TIMEOUT => 1000,
     YAR_OPT_PACKAGER => "json",
 ]);
@@ -86,7 +86,7 @@ $client = new Yar_Client("http://host/api/", [
  <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
-   <member><methodname>Yar_Client::__call</methodname></member>
+   <member><methodname>Yar_Client::call</methodname></member>
    <member><methodname>Yar_Client::setOpt</methodname></member>
   </simplelist>
  </refsect1>

--- a/reference/yar/yar_client/getopt.xml
+++ b/reference/yar/yar_client/getopt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: laruence Status: ready -->
+<!-- EN-Revision: 60ce1c5c7cc6d340191828de21f1d6b48cd83807 Maintainer: laruence Status: ready -->
 <refentry xml:id="yar-client.getopt" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yar_Client::getOpt</refname>
@@ -50,7 +50,7 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$client = new Yar_Client("http://host/api/");
+$client = new Yar_Client("http://api.example.com/operator.php");
 $client->setOpt(YAR_OPT_TIMEOUT, 1000);
 
 var_dump($client->getOpt(YAR_OPT_TIMEOUT));

--- a/reference/yar/yar_client/setopt.xml
+++ b/reference/yar/yar_client/setopt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: mowangjuanzi Status: ready -->
+<!-- EN-Revision: 60ce1c5c7cc6d340191828de21f1d6b48cd83807 Maintainer: mowangjuanzi Status: ready -->
 <!-- CREDITS: Luffy -->
 <refentry xml:id="yar-client.setopt" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -86,7 +86,7 @@
    <listitem>
     <simpara>
      每个选项都要求特定类型的值（字符串、布尔、整型或数组），
-     具体说明见常量页。
+     具体说明见常量页面。
     </simpara>
    </listitem>
   </itemizedlist>
@@ -100,7 +100,7 @@
 <![CDATA[
 <?php
 
-$client = new Yar_Client("http://host/api/");
+$client = new Yar_Client("http://api.example.com/operator.php");
 
 /* 设置超时时间为 1 秒 */
 $client->setOpt(YAR_OPT_TIMEOUT, 1000);
@@ -126,7 +126,7 @@ $result = $client->some_method("parameter");
   &reftitle.seealso;
   <simplelist>
    <member><methodname>Yar_Client::getOpt</methodname></member>
-   <member><methodname>Yar_Client::__call</methodname></member>
+   <member><methodname>Yar_Client::call</methodname></member>
   </simplelist>
  </refsect1>
 

--- a/reference/yar/yar_client_exception/gettype.xml
+++ b/reference/yar/yar_client_exception/gettype.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: mowangjuanzi Status: ready -->
+<!-- EN-Revision: 60ce1c5c7cc6d340191828de21f1d6b48cd83807 Maintainer: mowangjuanzi Status: ready -->
 <refentry xml:id="yar-client-exception.gettype" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yar_Client_Exception::getType</refname>
@@ -42,7 +42,7 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$client = new Yar_Client("http://host/api/");
+$client = new Yar_Client("http://api.example.com/operator.php");
 
 try {
     $client->some_method("parameter");

--- a/reference/yar/yar_concurrent_client/call.xml
+++ b/reference/yar/yar_concurrent_client/call.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: mowangjuanzi Status: ready -->
+<!-- EN-Revision: 60ce1c5c7cc6d340191828de21f1d6b48cd83807 Maintainer: mowangjuanzi Status: ready -->
 <refentry xml:id="yar-concurrent-client.call" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yar_Concurrent_Client::call</refname>
@@ -25,7 +25,8 @@
   </simpara>
   <note>
    <simpara>
-    仅支持 HTTP 和 HTTPS URI。并发调用不支持 TCP 和 Unix socket 传输方式。
+    仅支持 HTTP 和 HTTPS URI。并发调用通过 curl 的 multi-handle 接口同时发出，
+    TCP/Unix socket 传输方式没有提供该能力。
    </simpara>
   </note>
  </refsect1>
@@ -63,12 +64,18 @@
     <listitem>
      <simpara>
       当此次调用的响应到达时调用的 <type>callable</type>，
-      接收两个参数：响应值，以及一个包含
-      <literal>sequence</literal>、<literal>uri</literal> 和
-      <literal>method</literal> 三个键的 <literal>callinfo</literal> &array;。
+      接收两个参数：响应值，以及一个描述该调用的
+      <literal>callinfo</literal> &array;：
+     </simpara>
+     <simplelist>
+      <member><literal>sequence</literal> ——注册该调用时返回的序列号</member>
+      <member><literal>uri</literal> ——服务的地址</member>
+      <member><literal>method</literal> ——远程方法的名称</member>
+     </simplelist>
+     <simpara>
       如果省略，则使用
       <methodname>Yar_Concurrent_Client::loop</methodname> 的
-      <literal>callback</literal>。
+      <literal>callback</literal>；两者都不设置时的行为参见该方法。
      </simpara>
     </listitem>
    </varlistentry>
@@ -78,10 +85,10 @@
      <simpara>
       当此次调用失败时调用的 <type>callable</type>，
       接收三个参数：错误类型（<literal>YAR_ERR_*</literal>
-      错误码之一）、错误消息，以及 <literal>callinfo</literal> &array;。
+      错误码之一）、错误消息，以及上述的 <literal>callinfo</literal> &array;。
       如果省略，则使用
       <methodname>Yar_Concurrent_Client::loop</methodname> 的
-      <literal>error_callback</literal>。
+      <literal>error_callback</literal>；两者都不设置时的行为参见该方法。
      </simpara>
     </listitem>
    </varlistentry>
@@ -129,16 +136,16 @@ function error_callback($type, $error, $callinfo)
     error_log($error);
 }
 
-Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback");
+Yar_Concurrent_Client::call("http://api.example.com/operator.php", "some_method", array("parameters"), "callback");
 
-/* 如果不指定回调, 将使用 loop() 的回调 */
-Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"));
+/* 如果不指定回调，将使用 loop() 的回调 */
+Yar_Concurrent_Client::call("http://api.example.com/operator.php", "some_method", array("parameters"));
 
 /* 该服务器接受 JSON 打包器 */
-Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback", NULL, array(YAR_OPT_PACKAGER => "json"));
+Yar_Concurrent_Client::call("http://api.example.com/operator.php", "some_method", array("parameters"), "callback", NULL, array(YAR_OPT_PACKAGER => "json"));
 
 /* 自定义超时时间 */
-Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback", NULL, array(YAR_OPT_TIMEOUT => 1000));
+Yar_Concurrent_Client::call("http://api.example.com/operator.php", "some_method", array("parameters"), "callback", NULL, array(YAR_OPT_TIMEOUT => 1000));
 
 /* 此时请求尚未发送 */
 ]]>

--- a/reference/yar/yar_concurrent_client/loop.xml
+++ b/reference/yar/yar_concurrent_client/loop.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: mowangjuanzi Status: ready -->
+<!-- EN-Revision: 60ce1c5c7cc6d340191828de21f1d6b48cd83807 Maintainer: mowangjuanzi Status: ready -->
 <refentry xml:id="yar-concurrent-client.loop" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yar_Concurrent_Client::loop</refname>
@@ -21,6 +21,18 @@
    并阻塞直到每一个响应都已到达并被处理完毕。
    此方法返回时，调用列表会被清空。
   </simpara>
+  <simpara>
+   由于这些调用是同时执行的，loop 的耗时只等于最慢单次调用的耗时，
+   而不是所有调用耗时之和。但回调不会按照调用注册的顺序触发：
+   哪个响应先到达，就先触发哪个回调。要确定某个响应属于哪次调用，
+   可以将 <literal>callinfo</literal> 参数中的
+   <literal>sequence</literal> 与
+   <methodname>Yar_Concurrent_Client::call</methodname>
+   返回的序列号进行对照。<literal>callinfo</literal> &array;
+   包含该调用的 <literal>sequence</literal>、<literal>uri</literal> 和
+   <literal>method</literal>；参见
+   <methodname>Yar_Concurrent_Client::call</methodname>。
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -30,9 +42,12 @@
     <term><parameter>callback</parameter></term>
     <listitem>
      <simpara>
-      用于处理注册时没有指定自身回调的调用的响应的 <type>callable</type>。
-      在全部请求发送完毕后，它还会先于任何响应到达之前，
-      额外被调用一次，此时两个参数均为 &null;。
+      <type>callable</type>，用于处理未指定自身回调的调用的响应。
+      在全部请求发送完毕后、任何响应到达之前，它还会额外被调用一次，
+      此时两个参数均为 &null;。
+     </simpara>
+     <simpara>
+      如果省略该参数，成功调用的返回值会在其响应到达时被直接打印输出。
      </simpara>
     </listitem>
    </varlistentry>
@@ -40,9 +55,14 @@
     <term><parameter>error_callback</parameter></term>
     <listitem>
      <simpara>
-      用于处理注册时没有指定自身错误回调的调用的错误的 <type>callable</type>。
+      <type>callable</type>，用于处理未指定自身错误回调的调用的错误。
       接收三个参数：错误类型（<literal>YAR_ERR_*</literal>
       错误码之一）、错误消息，以及 <literal>callinfo</literal> &array;。
+     </simpara>
+     <simpara>
+      如果省略该参数，失败的调用会改为触发一条 PHP 警告；
+      这一点与同步的 <classname>Yar_Client</classname> 不同，
+      后者会抛出异常。
      </simpara>
     </listitem>
    </varlistentry>
@@ -89,10 +109,10 @@ function error_callback($type, $error, $callinfo) {
     error_log($error);
 }
 
-Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback");
+Yar_Concurrent_Client::call("http://api.example.com/operator.php", "some_method", array("parameters"), "callback");
 
-/* 如果不指定回调, 将使用 loop() 的回调 */
-Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"));
+/* 如果不指定回调，将使用 loop() 的回调 */
+Yar_Concurrent_Client::call("http://api.example.com/operator.php", "some_method", array("parameters"));
 
 Yar_Concurrent_Client::loop("callback", "error_callback");
 ?>

--- a/reference/yar/yar_concurrent_client/reset.xml
+++ b/reference/yar/yar_concurrent_client/reset.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: laruence Status: ready -->
+<!-- EN-Revision: 60ce1c5c7cc6d340191828de21f1d6b48cd83807 Maintainer: laruence Status: ready -->
 <refentry xml:id="yar-concurrent-client.reset" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yar_Concurrent_Client::reset</refname>
@@ -50,9 +50,9 @@ function callback($retval, $callinfo) {
     var_dump($retval);
 }
 
-Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback");
+Yar_Concurrent_Client::call("http://api.example.com/operator.php", "some_method", array("parameters"), "callback");
 
-/* 从未发送: 丢弃已注册的调用 */
+/* 从未发送：丢弃已注册的调用 */
 Yar_Concurrent_Client::reset();
 ?>
 ]]>

--- a/reference/yar/yar_server/construct.xml
+++ b/reference/yar/yar_server/construct.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: mowangjuanzi Status: ready -->
+<!-- EN-Revision: 60ce1c5c7cc6d340191828de21f1d6b48cd83807 Maintainer: mowangjuanzi Status: ready -->
 <refentry xml:id="yar-server.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yar_Server::__construct</refname>
@@ -28,6 +28,40 @@
      <simpara>
       任意一个对象，其公开方法将被作为 RPC 服务对外暴露。
       受保护和私有方法，以及方法名以下划线开头的方法，不会被暴露。
+     </simpara>
+     <simpara>
+      执行对象还可以定义两个受保护的魔法方法，
+      它们会被 <methodname>Yar_Server::handle</methodname>
+      识别，且永远不会作为 RPC 端点对外暴露：
+     </simpara>
+     <itemizedlist>
+      <listitem>
+       <simpara>
+        <literal>protected function __info(string $markup):
+        string</literal> — 自 Yar 2.3.0 起。在请求服务信息页面时被调用；
+        它接收 Yar 原本要渲染的页面标记（markup），
+        如果返回一个 &string;，该字符串会被发送给客户端，
+        替代默认的页面。参见
+        <methodname>Yar_Server::handle</methodname>。
+       </simpara>
+      </listitem>
+      <listitem>
+       <simpara>
+        <literal>protected function __auth(string $provider, string
+        $token): bool</literal> — 自 Yar 2.3.0 起。在每个请求处理的最开始被调用，
+        请求头中的 <literal>provider</literal> 和
+        <literal>token</literal> 字段会作为参数传入，
+        这两个字段由客户端通过
+        <constant>YAR_OPT_PROVIDER</constant> 和
+        <constant>YAR_OPT_TOKEN</constant> 选项设置。
+        严格返回 &false; 表示拒绝该请求；任何其他返回值都会让请求继续。
+        参见 <methodname>Yar_Server::handle</methodname>。
+       </simpara>
+      </listitem>
+     </itemizedlist>
+     <simpara>
+      这两个方法只有在声明为 <literal>protected</literal> 时才生效；
+      同名的公开或私有方法会被忽略。
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/yar/yar_server/handle.xml
+++ b/reference/yar/yar_server/handle.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 07275f5d03cf34c5a2218e0c103978f8024da153 Maintainer: mowangjuanzi Status: ready -->
+<!-- EN-Revision: 60ce1c5c7cc6d340191828de21f1d6b48cd83807 Maintainer: mowangjuanzi Status: ready -->
 <refentry xml:id="yar-server.handle" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yar_Server::handle</refname>
@@ -28,12 +28,10 @@
   </note>
   <note>
    <simpara>
-    自 Yar 2.3.0 起，可以在执行对象上定义一个名为
-    <literal>__info</literal> 的 <literal>protected</literal> 方法，
-    以自定义服务信息页面。当 GET 请求到达时，Yar 会调用该方法，
-    并将它原本要渲染的页面标记（markup）作为参数传入；
-    如果该方法返回一个 &string;，这个字符串会被发送给客户端，
-    替代默认的页面。
+    自 Yar 2.3.0 起，执行对象可以定义受保护的魔法方法
+    <literal>__info</literal> 和 <literal>__auth</literal>，
+    分别用于自定义服务信息页面和验证请求的身份；
+    详情参见 <methodname>Yar_Server::__construct</methodname>。
    </simpara>
   </note>
  </refsect1>
@@ -160,8 +158,8 @@ class API {
     }
 
     /*
-     * 必须声明为 protected。当收到 GET 请求时调用,
-     * 传入 Yar 原本要渲染的页面标记(markup),
+     * 必须声明为 protected。当收到 GET 请求时调用，
+     * 传入 Yar 原本要渲染的页面标记（markup），
      * 其返回的字符串会被发送给客户端以替代默认页面。
      */
     protected function __info($markup) {

--- a/reference/yar/yar_server_exception/gettype.xml
+++ b/reference/yar/yar_server_exception/gettype.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: mowangjuanzi Status: ready -->
+<!-- EN-Revision: 60ce1c5c7cc6d340191828de21f1d6b48cd83807 Maintainer: mowangjuanzi Status: ready -->
 <refentry xml:id="yar-server-exception.gettype" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yar_Server_Exception::getType</refname>
@@ -59,7 +59,7 @@ $service->handle();
 <![CDATA[
 <?php
 /* Client.php */
-$client = new Yar_Client("http://host/api.php");
+$client = new Yar_Client("http://api.example.com/operator.php");
 
 try {
     $client->throw_exception("client");


### PR DESCRIPTION
## 摘要

跟进英文文档修订（php/doc-en#5815，已合入），同步更新 `reference/yar/` 全部中文翻译，EN-Revision 对齐 `60ce1c5c7c`。

## 变更内容

**1. 新增《Yar 协议》章节**（置于安装章节之前）

- 描述 82 字节二进制请求头布局、打包器标识前缀的消息体及网络字节序字段
- 附带一个不依赖扩展、仅用标准 PHP 调用 Yar 服务的完整示例
- 补充 `YAR_ERR_FORBIDDEN` 常量（服务端鉴权失败错误码，此前手册缺失）

**2. 安装章节更新**

- 覆盖三种安装方式：PECL（标注已迁移）、PIE（`pie install laruence/yar`，含 `--enable-msgpack` 变体）以及从源码构建

**3. 示例与使用说明完善**

- `Yar_Client::call()` 新增示例：魔法方法调用形式、显式按名调用形式，以及远程方法恰好叫 `call` 时为何需要显式调用
- `Yar_Concurrent_Client` 补充设计动机（批量发起互相独立的调用，整体等待时间降为最慢单次调用）、仅支持 HTTP(S) 的原因（并发调用通过 curl multi-handle 接口发出，TCP/Unix socket 传输层未实现该能力）、`callinfo` 数组组成，以及未设置 callback/error_callback 时的兜底行为（直接打印返回值 / 触发 PHP 警告）

## 验证

- `doc-base/configure.php --with-lang=zh --with-partial=book.yar` 校验通过
- `phd`（PHP chunked XHTML 包）渲染无错误