### PR TITLE
新增 Yac 内存管理章节并同步 doc-en #5822 的文档更新

### DIFF
--- a/reference/yac/book.xml
+++ b/reference/yac/book.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: d3a03f8f542cd083d793bbd8ef3d7756aae7711f Maintainer: Laruence Status: ready -->
+<!-- EN-Revision: c05fbe7250c43b75034ac776ed78f4e67163e4d3 Maintainer: Laruence Status: ready -->
 
 <book xml:id="book.yac" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <?phpdoc extension-membership="pecl" ?>
@@ -10,48 +10,32 @@
  <preface xml:id="intro.yac">
   &reftitle.intro;
   <simpara>
-   Yac（Yet Another Cache）是一个无锁（lock-free）的共享内存用户数据缓存，
-   可以用来替代 APC 或本地 memcached。
+   Yac（Yet Another Cache）是一个无锁（lock-free）的共享内存用户数据缓存，可以用来替代 APC 或本地 memcached。
   </simpara>
   <simpara>
-   Yac 将数据存储在共享内存中，同一台机器上的每个 PHP 工作进程
-   都能直接访问，无需任何进程间通信。
-   Yac 不加锁，而是依靠原子的槽位更新加上少量的冲突探测，
-   因此缓存未命中（cache miss）绝不会阻塞请求；
-   并发写入最坏的情况也只是某次存储失败或某次读取落空，
-   调用方直接重试即可。
+   Yac 将数据存储在共享内存中，同一台机器上的每个 PHP 工作进程都能直接访问，无需任何进程间通信。
+   Yac 不加锁，而是依靠原子的槽位更新加上少量的冲突探测，因此缓存未命中（cache miss）绝不会阻塞请求；并发写入最坏的情况也只是某次存储失败或某次读取落空，调用方直接重试即可。
   </simpara>
   <simpara>
-   访问路径上没有锁，也没有进程间通信，一次读取本质上就是
-   在共享内存中做一次哈希查找。因此，Yac 极其快，
-   读取延迟在微秒级；只要写入分散在不同的键上，
-   吞吐量还能随着访问缓存的 worker 数量增长。
+   访问路径上没有锁，也没有进程间通信，一次读取本质上就是在共享内存中做一次哈希查找。因此，Yac 极其快，读取延迟在微秒级；只要写入分散在不同的键上，吞吐量还能随着访问缓存的 worker 数量增长；参见
+   <link xlink:href="&url.git.hub;laruence/yac/blob/master/README.md#benchmarks">基准测试</link>。
   </simpara>
   <simpara>
-   由于 Yac 用正确性保证换取速度和吞吐量，
-   它最适合缓存那些生成代价高但可以轻易重建的数据：
-   页面片段、配置快照、小型服务响应等本地缓存。
-   不要把它用作不可替代数据的权威存储。
+   由于 Yac 用正确性保证换取速度和吞吐量，它最适合缓存那些生成代价高但可以轻易重建的数据：页面片段、配置快照、小型服务响应等本地缓存。不要把它用作不可替代数据的权威存储。
   </simpara>
   <simpara>
-   从 yac 2.4.0 开始，小标量值——<constant>NULL</constant>、
-   布尔值、整数、最长 7 字节的短字符串和空数组——
-   直接存储在哈希槽（hash slot）里，而不是单独的值块
-   （即“嵌入值”，embedded values）。这样每次访问都省去了
-   值内存的分配和块拷贝，显著提升性能的同时减少了内存占用。
-   2.4.0 还把压缩后端从 FastLZ 换成了 LZ4，
-   使压缩数据的读取快了好几倍。
+   从 yac 2.4.0 开始，小标量值——<constant>NULL</constant>、布尔值、大多数整数（在 64 位构建下能装进 60 个有符号位的整数）、最长 7 字节的字符串和空数组——直接存储在哈希槽（hash slot）里，而不是单独的值块（即“嵌入值”，embedded values）。这样每次访问都省去了值内存的分配和块拷贝，显著提升性能的同时减少了内存占用。
+   2.4.0 还把压缩后端从 FastLZ 换成了 LZ4，使压缩数据的读取快了好几倍。
   </simpara>
   <note>
    <simpara>
-    共享内存仅在同一台机器内可见。
-    如果需要在多台服务器之间共享缓存，
-    请使用 Memcached 或 Redis 等网络缓存。
+    共享内存仅在同一台机器内可见。如果需要在多台服务器之间共享缓存，请使用 Memcached 或 Redis 等网络缓存。
    </simpara>
   </note>
  </preface>
 
  &reference.yac.setup;
+ &reference.yac.memory;
  &reference.yac.constants;
  <!-- &reference.yac.examples; -->
  &reference.yac.yac;

--- a/reference/yac/constants.xml
+++ b/reference/yac/constants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: Laruence Status: ready -->
+<!-- EN-Revision: c05fbe7250c43b75034ac776ed78f4e67163e4d3 Maintainer: Laruence Status: ready -->
 
 <appendix xml:id="yac.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.constants;
@@ -14,6 +14,7 @@
     </term>
     <listitem>
      <simpara>
+      扩展的版本号（字符串形式）。
      </simpara>
     </listitem>
    </varlistentry>
@@ -24,7 +25,7 @@
     </term>
     <listitem>
      <simpara>
-      键允许的最大长度，为 48 字节。
+      键的最大长度，单位为字节：48。实例前缀也计入该限制。
      </simpara>
     </listitem>
    </varlistentry>
@@ -35,6 +36,8 @@
     </term>
     <listitem>
      <simpara>
+      值在序列化前的最大长度，单位为字节：
+      67,108,863（<literal>(1 &lt;&lt; 26) - 1</literal>）。更大的值会被拒绝。
      </simpara>
     </listitem>
    </varlistentry>
@@ -45,6 +48,7 @@
     </term>
     <listitem>
      <simpara>
+      存储条目的最大尺寸，单位为字节：1,048,576（1M）。压缩后仍放不下的值会被拒绝。
      </simpara>
     </listitem>
    </varlistentry>
@@ -55,7 +59,7 @@
     </term>
     <listitem>
      <simpara>
-      使用 PHP serialize 作为序列化器。
+      使用 PHP serialize 作为序列化器（默认）。
      </simpara>
     </listitem>
    </varlistentry>
@@ -66,7 +70,8 @@
     </term>
     <listitem>
      <simpara>
-      使用 JSON 作为序列化器（需要 --enable-json）。
+      使用 JSON 作为序列化器。需要扩展以
+      <option role="configure">--enable-json</option> 支持编译。
      </simpara>
     </listitem>
    </varlistentry>
@@ -77,7 +82,8 @@
     </term>
     <listitem>
      <simpara>
-      使用 igbinary 作为序列化器（需要 --enable-igbinary）。
+      使用 igbinary 作为序列化器。需要扩展以
+      <option role="configure">--enable-igbinary</option> 支持编译。
      </simpara>
     </listitem>
    </varlistentry>
@@ -88,7 +94,8 @@
     </term>
     <listitem>
      <simpara>
-      使用 msgpack 作为序列化器（需要 --enable-msgpack）。
+      使用 msgpack 作为序列化器。需要扩展以
+      <option role="configure">--enable-msgpack</option> 支持编译。
      </simpara>
     </listitem>
    </varlistentry>
@@ -99,7 +106,7 @@
     </term>
     <listitem>
      <simpara>
-      Yac 当前使用的序列化器。
+      扩展当前使用的序列化器。
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/yac/ini.xml
+++ b/reference/yac/ini.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: Laruence Status: ready -->
+<!-- EN-Revision: c05fbe7250c43b75034ac776ed78f4e67163e4d3 Maintainer: Laruence Status: ready -->
 
 <section xml:id="yac.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;
@@ -20,7 +20,7 @@
     <tbody>
      <row>
       <entry><link linkend="ini.yac.compress-threshold">yac.compress_threshold</link></entry>
-      <entry>-1</entry>
+      <entry>4K</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
@@ -44,7 +44,7 @@
      </row>
      <row>
       <entry><link linkend="ini.yac.keys-memory-size">yac.keys_memory_size</link></entry>
-      <entry>4M</entry>
+      <entry>8M</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
@@ -76,9 +76,10 @@
      </term>
      <listitem>
       <simpara>
-       序列化后大于该字节数的值会在存储前被压缩（当前使用 LZ4）。
-       设为 <literal>-1</literal>（默认值）则完全禁用压缩。
-       压缩大值可以节省共享内存，代价是存取时多消耗一些 CPU。
+       序列化后大于该字节数的值会在存储前被压缩（自 Yac 2.4.0 起使用 LZ4）。超过
+       <literal>1M</literal> 存储条目上限（<constant>YAC_MAX_RAW_COMPRESSED_LEN</constant>）的值无论本设置如何都会被压缩，因为它们无法以未压缩形式存储。默认值 <literal>4K</literal> 表示开启压缩；
+       <literal>-1</literal> 对低于存储条目上限的值禁用压缩；其他正值会被钳制到 <literal>1024</literal>..<literal>1M</literal>
+       区间内。压缩大值可以节省共享内存，代价是存取时多消耗一些 CPU。
       </simpara>
      </listitem>
     </varlistentry>
@@ -112,9 +113,7 @@
      </term>
      <listitem>
       <simpara>
-       在 <literal>CLI</literal> SAPI 下运行时是否启用 Yac。
-       默认禁用，因为命令行脚本通常启动后立即结束，
-       创建共享内存段毫无意义。
+       在 <literal>CLI</literal> SAPI 下运行时是否启用 Yac。默认禁用，因为命令行脚本通常启动后立即结束，创建共享内存段毫无意义。
       </simpara>
      </listitem>
     </varlistentry>
@@ -125,11 +124,7 @@
      </term>
      <listitem>
       <simpara>
-       用于存放键和元信息的哈希槽位所占用的共享内存大小。
-       每个槽位是固定大小的结构，因此这个值决定了能同时跟踪多少条目。
-       默认为 <literal>4M</literal>。
-       Yac 将这块区域切分成若干段，每段大小为 4M，
-       因此该值必须是 <literal>4M</literal> 的倍数。
+       用于存放键表的共享内存大小。它限制了能同时存在的条目数量——默认的 <literal>8M</literal> 大约能容纳 65,536 个条目。如果命中率下降且 <literal>kicks</literal> 攀升，请调大该值；关于键表写满后的行为以及何时才真正构成问题，参见<xref linkend="yac.memory-management"/>。
       </simpara>
      </listitem>
     </varlistentry>
@@ -140,13 +135,10 @@
      </term>
      <listitem>
       <simpara>
-       存储前把任意 PHP 值转换成字节序列所用的序列化器。
-       可选值为 <literal>php</literal>（默认）、<literal>json</literal>、
-       <literal>igbinary</literal> 和 <literal>msgpack</literal>。
-       后三者需要扩展以相应支持编译。
+       存储前把任意 PHP 值转换成字节序列所用的序列化器。可选值为 <literal>php</literal>（默认）、<literal>json</literal>、
+       <literal>igbinary</literal> 和 <literal>msgpack</literal>。后三者需要扩展以相应支持编译。
        <literal>igbinary</literal> 和 <literal>msgpack</literal>
-       等二进制序列化器通常比 <literal>php</literal> 更快，
-       产生的数据也更小。
+       等二进制序列化器通常比 <literal>php</literal> 更快，产生的数据也更小。
       </simpara>
      </listitem>
     </varlistentry>
@@ -157,10 +149,10 @@
      </term>
      <listitem>
       <simpara>
-       用于存放实际值的共享内存大小，默认为 <literal>64M</literal>。
-       Yac 以每段 4M 的方式分配这块区域，
-       因此该值必须是 <literal>4M</literal> 的倍数。
-       当区域写满时，最久未使用的条目会被踢出，为新条目腾出空间。
+       用于存放值的共享内存大小。值在一个个 4M 的段上，由一个只进不退的分配器（bump allocator）分配；当没有任何段装得下新值时，分配器游标会绕回起点，最旧的值会被悄悄覆盖（即一次回收，
+       <literal>recycle</literal>）。此后对它们的读取会退化为未命中，由一个完整性校验机制检出。如果在槽位尚有余量时 <literal>recycles</literal> 仍在攀升，请调大该值；或者启用
+       <link linkend="ini.yac.compress-threshold">yac.compress_threshold</link>
+       来压缩大载荷。参见<xref linkend="yac.memory-management"/>。
       </simpara>
      </listitem>
     </varlistentry>
@@ -168,7 +160,6 @@
   </variablelist>
  </para>
 </section>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/yac/memory.xml
+++ b/reference/yac/memory.xml
@@ -1,0 +1,173 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: c05fbe7250c43b75034ac776ed78f4e67163e4d3 Maintainer: Laruence Status: ready -->
+
+<chapter xml:id="yac.memory-management" xmlns="http://docbook.org/ns/docbook">
+ <title>内存管理</title>
+
+ <simpara>
+  Yac 把数据存放在两个相互独立的共享内存池里，分别由
+  <link linkend="ini.yac.keys-memory-size">yac.keys_memory_size</link>
+  和
+  <link linkend="ini.yac.values-memory-size">yac.values_memory_size</link>
+  配置。两个池写满和释放的方式各不相同，因此在调整任何一个参数之前，先弄清楚症状属于哪个池会很有帮助。
+ </simpara>
+
+ <section xml:id="yac.memory-layout" annotations="chunk:false">
+  <title>每个池各存放什么</title>
+  <simpara>
+   两个池分别存放一个条目的两半。键池存放键：每个被缓存的键占一个槽位，槽位里带着键本身（最长 48 字节）、哈希值、TTL、命中次数和最后访问时间；值只通过一个指向值池的指针被引用。值池存放值：每个存储的值占用一块序列化后的字节——如果条目经过了
+   <link linkend="ini.yac.compress-threshold">yac.compress_threshold</link>，则是压缩后的形式。
+  </simpara>
+  <simpara>
+   唯一的例外是嵌入值（embedded values）：极小的标量——&null;、
+   &true;、&false;、大多数整数（在 64 位构建下能装进 60 个有符号位的整数）、最长 7 字节的字符串和空数组——直接存放在槽位内部，用的正是本来要引用值块的那个指针。这样的值在值池中完全不占空间，只有它们的键占位。
+  </simpara>
+  <para>
+   粗略的容量规划方法：
+   <itemizedlist>
+    <listitem>
+     <simpara>
+      键池每 MB 大约能容纳 8,000 个键，因此
+      <link linkend="ini.yac.keys-memory-size">yac.keys_memory_size</link>
+      可以按不同键的数量除以每 MB 8,000 个、再向上取整来估算——默认的 <literal>8M</literal> 大约能容纳 64,000 个键；
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      值池必须容纳所有仍可能被读取的值，因此
+      <link linkend="ini.yac.values-memory-size">yac.values_memory_size</link>
+      可以按存活值的数量乘以平均序列化（压缩后）大小来估算，并预留大约两倍的空间：这个池是一个环，只有当分配器的游标绕回来覆盖某个值时，它才算消亡。
+     </simpara>
+    </listitem>
+   </itemizedlist>
+   嵌入值和其他条目一样占用槽位，但在值池中不占空间，因此计算第二项时不必把它们算进去。
+  </para>
+ </section>
+
+ <section xml:id="yac.memory-keys" annotations="chunk:false">
+  <title>键池（槽位）</title>
+  <simpara>
+   <link linkend="ini.yac.keys-memory-size">yac.keys_memory_size</link>
+   维护着一张固定大小的槽位表——默认的 <literal>8M</literal>
+   大约有 65,536 个槽位。每个存储的键恰好占用一个槽位，因此这个池限制了同时能存在的条目数量；与值池不同，槽位永远不会被单独释放。过期的槽位——TTL 已过的，或者 <methodname>Yac::delete</methodname> 留下的墓碑——在新键需要时会被免费回收。只有当某条探测路径上的四个候选槽位全部被存活条目占据时，才会驱逐其中一个来腾出空间——这记一次 <literal>kick</literal>（对应
+   <methodname>Yac::info</methodname> 的
+   <literal>kicks</literal> 计数器）。
+  </simpara>
+  <para>
+   驱逐只在发生碰撞的探测路径上的四个存活候选者中挑选：
+   <itemizedlist>
+    <listitem>
+     <simpara>
+      最近最少使用的那个（<literal>atime</literal> 最旧）会被驱逐；
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      打平时选命中次数最少的，再打平选探测位置最靠前的。
+     </simpara>
+    </listitem>
+   </itemizedlist>
+  </para>
+  <simpara>
+   一个常见的误解：<literal>slots_used</literal> 达到
+   <literal>slots_size</literal> <emphasis>并不</emphasis>是错误状态。一个键的工作集大于槽位表的缓存，此后只是以 100% 的占用率运行，按需驱逐和重新插入而已。判断键池大小是否合适的唯一指标是命中率（<literal>hits / (hits + miss)</literal>，按两次
+   <methodname>Yac::info</methodname> 快照之间的增量计算，而不是全生命周期的平均值）。单看 <literal>kicks</literal> 计数很高并不能说明有问题——只是键的分布不均匀，某些探测路径碰撞更多而已。只有当命中率和 <literal>kicks</literal> <emphasis>同时</emphasis>很糟时，才说明槽位表对这个键集合来说太小了，解决办法是调大
+   <link linkend="ini.yac.keys-memory-size">yac.keys_memory_size</link>。
+  </simpara>
+  <simpara>
+   槽位永不释放还有一个后果：没有 TTL（<literal>ttl = 0</literal>）又再也没被读取过的条目会一直占着槽位，直到某次驱逐恰好选中它。如果应用要存放大量这类一次性数据，请给这些条目设置 TTL，让它们过期后被回收，而不是挤掉存活的条目；或者干脆按全部键集合的大小来规划键池。
+  </simpara>
+ </section>
+
+ <section xml:id="yac.memory-values" annotations="chunk:false">
+  <title>值池（段）</title>
+  <simpara>
+   <link linkend="ini.yac.values-memory-size">yac.values_memory_size</link>
+   被切分成每段 4M，按环形管理：写入推进各段的游标，空间从不按条目释放。当一次分配放不下时，游标绕回某段的起点——这记一次 <literal>recycle</literal>（对应
+   <methodname>Yac::info</methodname> 的
+   <literal>recycles</literal> 计数器）。一次回收并不会立即使整段失效：被覆盖的值在绕回的游标真正覆盖到它们之前仍然可读，一旦被覆盖，对它们的读取就会通不过完整性校验而退化为未命中。
+  </simpara>
+  <simpara>
+   这个池有两个大小值得关注：总的
+   <link linkend="ini.yac.values-memory-size">yac.values_memory_size</link>
+   必须装得下存活值的工作集，而单个条目存储后最多占 1 MB
+   （<constant>YAC_MAX_RAW_COMPRESSED_LEN</constant>）。因此更大的值在存储前总会被压缩；一个压不进 1 MB 以内的值——最常见的原因是数据本身是随机的——会被拒绝，并使 <literal>fails</literal> 计数器加一。值本身的绝对上限要高得多：序列化后超过 64 MB
+   （<constant>YAC_MAX_VALUE_RAW_LEN</constant>，即
+   <literal>(1 &lt;&lt; 26) - 1</literal> 字节）的值会被直接拒绝。
+  </simpara>
+ </section>
+
+ <section xml:id="yac.memory-tuning" annotations="chunk:false">
+  <title>容量规划与观察指标</title>
+  <simpara>
+   从默认值起步，然后观察
+   <methodname>Yac::info</methodname> 的各计数器——它们从 <literal>start_time</literal> 起累加，所以要比较相隔一段时间的两个快照：
+  </simpara>
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     命中率健康（比如 &gt;= 90%）：缓存工作正常，无论其他计数器显示什么，都不用管；
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     命中率低且 <literal>kicks</literal> 攀升：键池对这个键集合来说太小——存活条目在被重新读取之前就被驱逐了。调大
+     <link linkend="ini.yac.keys-memory-size">yac.keys_memory_size</link>；
+    </simpara>
+   </listitem>
+   <listitem>
+    <para>
+     <literal>recycles</literal> 频繁：这是真问题，不是无害的计数。一次回收意味着值分配器已经绕回、即将覆盖条目——被覆盖的值在重新读取之前就消亡了，存它花掉的字节白花了，命中率也会受损。这说明值池对存活数据的体量来说太小了。按效果排序：
+     <itemizedlist>
+      <listitem>
+       <simpara>
+        给条目设置 TTL。以 <literal>ttl = 0</literal> 写入的值永远存活，一直占着池子，迫使游标更早绕回。TTL 限定了每个条目的存活时长，缩小了池子必须容纳的存活工作集；
+       </simpara>
+      </listitem>
+      <listitem>
+       <simpara>
+        调大
+        <link linkend="ini.yac.values-memory-size">yac.values_memory_size</link>，让池子装得下整个存活值集合（记住要按存活占用大约两倍来预算——值只有在游标绕回来覆盖它时才消亡）；
+       </simpara>
+      </listitem>
+      <listitem>
+       <simpara>
+        减少单个条目的存储量：如果
+        <link linkend="ini.yac.compress-threshold">yac.compress_threshold</link>
+        设置得高于 <literal>1024</literal> 这个下限，把它调低，让大的载荷被压缩；精简那些不需要完整缓存的值；
+       </simpara>
+      </listitem>
+     </itemizedlist>
+    </para>
+   </listitem>
+   <listitem>
+    <simpara>
+     <literal>fails</literal> 增长：有值存不进去，最常见的是单个值压缩后仍超过 1 MB 的存储上限——把值拆分。
+    </simpara>
+   </listitem>
+  </itemizedlist>
+ </section>
+
+</chapter>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/yac/yac/add.xml
+++ b/reference/yac/yac/add.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: Laruence Status: ready -->
+<!-- EN-Revision: c05fbe7250c43b75034ac776ed78f4e67163e4d3 Maintainer: Laruence Status: ready -->
 
 <refentry xml:id="yac.add" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -12,7 +12,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier> <type>bool</type><methodname>Yac::add</methodname>
-   <methodparam><type class="union"><type>string</type><type>array</type></type><parameter>keys</parameter></methodparam>
+   <methodparam><type class="union"><type>string</type><type>array</type></type><parameter>key</parameter></methodparam>
    <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>ttl</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
@@ -22,8 +22,7 @@
    <methodparam choice="opt"><type>int</type><parameter>ttl</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <simpara>
-   向缓存中存储一个值。与 <methodname>Yac::set</methodname> 不同，
-   它不会覆盖仍然有效的已有条目；遇到这种情况时存储会被拒绝。
+   向缓存中存储一个值。与 <methodname>Yac::set</methodname> 不同，它不会覆盖仍然有效的已有条目；遇到这种情况时存储会被拒绝。
   </simpara>
  </refsect1>
 
@@ -31,7 +30,7 @@
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
-    <term><parameter>keys</parameter></term>
+    <term><parameter>key</parameter></term>
     <listitem>
      <simpara>
       <type>string</type> 类型的键，或者一个由
@@ -44,9 +43,7 @@
     <term><parameter>value</parameter></term>
     <listitem>
      <simpara>
-      要存储的值。除 <type>resource</type> 外的所有 PHP 类型都可以存储。
-      仅在单键形式下使用；当 <parameter>keys</parameter> 是数组时，
-      该参数位置实际上是可选的 <parameter>ttl</parameter>。
+      要存储的值。除 <type>resource</type> 外的所有 PHP 类型都可以存储。仅在单键形式下使用；当 <parameter>key</parameter> 是数组时，该参数位置实际上是可选的 <parameter>ttl</parameter>。
      </simpara>
     </listitem>
    </varlistentry>
@@ -64,24 +61,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   成功时返回 &true;，失败时返回 &false;。
-   当键已存在且未过期时，存储同样会被拒绝（返回 &false;）。
+   成功时返回 &true;，失败时返回 &false;。当键已存在且未过期时，存储同样会被拒绝（返回 &false;）。
   </simpara>
-  <note>
-   <para>
-    Yac 存储条目时不加锁。在高并发竞争下，存储可能会瞬时失败；
-    如果该值必须最终写入成功，请重试：
-    <programlisting role="php">
-<![CDATA[
-<?php
-while (!$yac->add("key", "value")) {
-    // 瞬时失败时重试
-}
-?>
-]]>
-    </programlisting>
-   </para>
-  </note>
  </refsect1>
 
  <refsect1 role="examples">
@@ -95,11 +76,31 @@ $yac = new Yac();
 
 var_dump($yac->add("foo", "bar"));          // bool(true)
 var_dump($yac->add("foo", "baz"));          // bool(false)："foo" 已存在
+?>
+]]>
+   </programlisting>
+  </example>
+  <example>
+   <title>添加带 TTL 的条目</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$yac = new Yac();
 
 // ttl 以秒为单位；0（默认值）表示条目永不过期
 $yac->add("short-lived", "value", 5);
 sleep(6);
 var_dump($yac->get("short-lived"));        // bool(false)：已过期
+?>
+]]>
+   </programlisting>
+  </example>
+  <example>
+   <title>一次添加多个条目</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$yac = new Yac();
 
 // 一次调用存储多个键值对，并指定 ttl
 $yac->add(array("a" => 1, "b" => 2), 60);

--- a/reference/yac/yac/delete.xml
+++ b/reference/yac/yac/delete.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: d3a03f8f542cd083d793bbd8ef3d7756aae7711f Maintainer: Laruence Status: ready -->
+<!-- EN-Revision: c05fbe7250c43b75034ac776ed78f4e67163e4d3 Maintainer: Laruence Status: ready -->
 
 <refentry xml:id="yac.delete" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -12,7 +12,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier> <type>bool</type><methodname>Yac::delete</methodname>
-   <methodparam><type class="union"><type>string</type><type>array</type></type><parameter>keys</parameter></methodparam>
+   <methodparam><type class="union"><type>string</type><type>array</type></type><parameter>key</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>delay</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <simpara>
@@ -20,14 +20,9 @@
   </simpara>
   <note>
    <simpara>
-    注意，Yac 并不会真正把条目从缓存中移除：删除只是把条目标记为
-    过期——<literal>delay</literal> 为 <literal>0</literal> 时立即过期——
-    只有当后续的写入恰好复用了这个哈希槽时，该条目才会被覆盖：
-    要么是同一个键被重新写入，要么是另一个键的插入恰好落在了这个槽上。
-    在那之前，槽位一直被占用，所以 <methodname>Yac::info</methodname>
+    注意，Yac 并不会真正把条目从缓存中移除：删除只是把条目标记为过期——<literal>delay</literal> 为 <literal>0</literal> 时立即过期——只有当后续的写入恰好复用了这个哈希槽时，该条目才会被覆盖：要么是同一个键被重新写入，要么是另一个键的插入恰好落在了这个槽上。在那之前，槽位一直被占用，所以 <methodname>Yac::info</methodname>
     报告的 <literal>slots_used</literal> 计数不会减少，
-    <methodname>Yac::dump</methodname> 也仍会列出这些已删除的条目；
-    检视 dump 输出时，需要自己检查 <literal>ttl</literal> 值把它们过滤掉。
+    <methodname>Yac::dump</methodname> 也仍会列出这些已删除的条目；检视 dump 输出时，需要自己检查 <literal>ttl</literal> 值把它们过滤掉。
    </simpara>
   </note>
  </refsect1>
@@ -36,7 +31,7 @@
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
-    <term><parameter>keys</parameter></term>
+    <term><parameter>key</parameter></term>
     <listitem>
      <simpara>
       <type>string</type> 类型的键，或者由待删除的键组成的
@@ -49,8 +44,7 @@
     <listitem>
      <simpara>
       条目变为失效前等待的秒数。省略或为 <literal>0</literal>
-      时，条目立即失效。正数值表示条目在这段时间内仍可读，
-      到期后才失效。
+      时，条目立即失效。正数值表示条目在这段时间内仍可读，到期后才失效。
      </simpara>
     </listitem>
    </varlistentry>
@@ -60,9 +54,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   成功时返回 &true;；键不在缓存中时返回 &false;。
-   由于删除只是把条目标记为过期，一个已删除但尚未被覆盖的键
-   仍然算作存在：再次删除同一个键会返回 &true;。
+   成功时返回 &true;；键不在缓存中时返回 &false;。由于删除只是把条目标记为过期，一个已删除但尚未被覆盖的键仍然算作存在：再次删除同一个键会返回 &true;。
   </simpara>
   <simpara>
    传入键的 <type>array</type> 时，只有当每个键都存在才返回
@@ -89,12 +81,33 @@ var_dump($yac->delete("never"));    // bool(false)：从未存储过
 // 已过期的条目仍然出现在 dump 里
 var_dump($yac->info()["slots_used"]); // int(1)
 print_r($yac->dump());                // "foo" 仍在列表中；其 ttl 已过期
+?>
+]]>
+   </programlisting>
+  </example>
+  <example>
+   <title>延迟删除</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$yac = new Yac();
 
-// 延迟删除：让条目再保持可读 60 秒
+// 条目在过期前再保持可读 60 秒
 $yac->set("tmp", "value");
 var_dump($yac->delete("tmp", 60));    // bool(true)
+?>
+]]>
+   </programlisting>
+  </example>
+  <example>
+   <title>一次删除多个键</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$yac = new Yac();
+$yac->set("tmp", "value");
 
-// 一次删除多个键时，只有当每个键都存在才返回 true
+// 只有当每个键都存在才返回 true
 var_dump($yac->delete(array("tmp", "nope"))); // bool(false)："nope" 不存在
 ?>
 ]]>

--- a/reference/yac/yac/dump.xml
+++ b/reference/yac/yac/dump.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: d3a03f8f542cd083d793bbd8ef3d7756aae7711f Maintainer: Laruence Status: ready -->
+<!-- EN-Revision: c05fbe7250c43b75034ac776ed78f4e67163e4d3 Maintainer: Laruence Status: ready -->
 
 <refentry xml:id="yac.dump" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -30,9 +30,7 @@
       返回条目的最大数量。
      </simpara>
      <simpara>
-      <parameter>limit</parameter> 传 <literal>-1</literal> 会导出缓存当前持有的全部条目。
-      注意，对大型缓存构建完整列表可能占用可观的内存；
-      内存紧张时，请改用 <parameter>limit</parameter> 和 <parameter>offset</parameter> 分页遍历。
+      <parameter>limit</parameter> 传 <literal>-1</literal> 会导出缓存当前持有的全部条目。注意，对大型缓存构建完整列表可能占用可观的内存；内存紧张时，请改用 <parameter>limit</parameter> 和 <parameter>offset</parameter> 分页遍历。
      </simpara>
     </listitem>
    </varlistentry>
@@ -40,9 +38,7 @@
     <term><parameter>offset</parameter></term>
     <listitem>
      <simpara>
-      收集前跳过的条目数。该参数自 PECL yac 2.4.0 起可用；
-      更早的版本总是从第一个条目开始。结合 <parameter>limit</parameter>，
-      可用于对储存条目超过单次调用返回上限的缓存进行分页遍历。
+      收集前跳过的条目数。该参数自 PECL yac 2.4.0 起可用；更早的版本总是从第一个条目开始。结合 <parameter>limit</parameter>，可用于对储存条目超过单次调用返回上限的缓存进行分页遍历。
      </simpara>
     </listitem>
    </varlistentry>
@@ -52,8 +48,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   返回一个 <type>array</type>，每个导出的条目对应一个元素。
-   每个元素本身也是描述该条目的数组：
+   返回一个 <type>array</type>，每个导出的条目对应一个元素。每个元素本身也是描述该条目的数组：
   </simpara>
   <variablelist>
    <varlistentry>
@@ -71,8 +66,7 @@
    <varlistentry>
     <term><literal>crc</literal></term>
     <listitem><simpara>
-     存储值的 CRC32 校验和，用于检测撕裂读取（torn read）。
-     内嵌（embedded）条目没有值块，该字段为 <literal>0</literal>。
+     存储值的 CRC32 校验和，用于检测撕裂读取（torn read）。内嵌（embedded）条目没有值块，该字段为 <literal>0</literal>。
     </simpara></listitem>
    </varlistentry>
    <varlistentry>
@@ -93,33 +87,27 @@
    <varlistentry>
     <term><literal>v_len</literal></term>
     <listitem><simpara>
-     值的长度，单位为字节。对于被压缩的条目，
-     这是压缩<emphasis>前</emphasis>原始值的长度
-     （自 yac 2.4.0 起；更早的版本报告的是存储的压缩后长度）。
+     值的长度，单位为字节。对于被压缩的条目，这是压缩<emphasis>前</emphasis>原始值的长度（自 yac 2.4.0 起；更早的版本报告的是存储的压缩后长度）。
     </simpara></listitem>
    </varlistentry>
    <varlistentry>
     <term><literal>c_len</literal></term>
     <listitem><simpara>
-     仅被压缩的条目有此字段（自 yac 2.4.0 起）：
-     实际存入共享内存的压缩数据长度，单位为字节。
-     对比 <literal>c_len</literal> 和 <literal>v_len</literal>
+     仅被压缩的条目有此字段（自 yac 2.4.0 起）：实际存入共享内存的压缩数据长度，单位为字节。对比 <literal>c_len</literal> 和 <literal>v_len</literal>
      可以看出每个条目通过压缩节省了多少空间。
     </simpara></listitem>
    </varlistentry>
    <varlistentry>
     <term><literal>size</literal></term>
     <listitem><simpara>
-     值块在共享内存中分配的大小，单位为字节。
-     内嵌条目为 <literal>0</literal>。
+     值块在共享内存中分配的大小，单位为字节。内嵌条目为 <literal>0</literal>。
     </simpara></listitem>
    </varlistentry>
    <varlistentry>
     <term><literal>atime</literal></term>
     <listitem><simpara>
      最后访问时间（Unix 时间），每次成功的
-     <methodname>Yac::get</methodname> 都会更新它。
-     缓存写满时，候选槽位中 <literal>atime</literal>
+     <methodname>Yac::get</methodname> 都会更新它。缓存写满时，候选槽位中 <literal>atime</literal>
      最旧的条目会最先被驱逐（自 yac 2.4.0 起）。
     </simpara></listitem>
    </varlistentry>
@@ -127,18 +115,14 @@
     <term><literal>hits</literal></term>
     <listitem><simpara>
      每个条目的命中计数器，每次成功的
-     <methodname>Yac::get</methodname> 都会使其递增；
-     条目被覆盖、删除或过期时重置（自 yac 2.4.0 起）。
+     <methodname>Yac::get</methodname> 都会使其递增；当条目被新的 <methodname>Yac::set</methodname> 或
+     <methodname>Yac::add</methodname> 覆盖时重置（自 yac 2.4.0 起）。
     </simpara></listitem>
    </varlistentry>
    <varlistentry>
     <term><literal>embedded</literal></term>
     <listitem><simpara>
-     值是否直接存储在槽位内部，而不是单独的值块中
-     （自 yac 2.4.0 起）。小值——<constant>NULL</constant>、
-     布尔值、小整数、不超过 7 字节的字符串和空数组——
-     以内嵌方式存储，完全不占用值内存；
-     这类条目的 <literal>crc</literal> 和 <literal>size</literal>
+     值是否直接存储在槽位内部，而不是单独的值块中（自 yac 2.4.0 起）。小值——<constant>NULL</constant>、布尔值、小整数、不超过 7 字节的字符串和空数组——以内嵌方式存储，完全不占用值内存；这类条目的 <literal>crc</literal> 和 <literal>size</literal>
      均报告为 <literal>0</literal>。
     </simpara></listitem>
    </varlistentry>
@@ -205,24 +189,25 @@ Array
 ]]>
    </screen>
    <simpara>
-    条目按槽位顺序列出，而不是按存储顺序。
-    内嵌条目（直接保存在槽位内部的小标量）的
-    <literal>crc</literal> 和 <literal>size</literal> 为零；
-    存储在独立值块中的条目带有校验和与块大小，
-    被压缩的条目还额外带有 <literal>c_len</literal>。
+    条目按槽位顺序列出，而不是按存储顺序。内嵌条目（直接保存在槽位内部的小标量）的
+    <literal>crc</literal> 和 <literal>size</literal> 为零；存储在独立值块中的条目带有校验和与块大小，被压缩的条目还额外带有 <literal>c_len</literal>。
    </simpara>
   </example>
   <example>
    <title>分页遍历大型缓存</title>
    <simpara>
     <parameter>limit</parameter> 限制单次调用返回的条目数，
-    <parameter>offset</parameter> 表示收集前跳过的条目数，
-    两者组合即可对储存条目超过单次调用返回上限的缓存进行分页遍历。
+    <parameter>offset</parameter> 表示收集前跳过的条目数，两者组合即可对储存条目超过单次调用返回上限的缓存进行分页遍历。
    </simpara>
    <programlisting role="php">
 <![CDATA[
 <?php
 $yac = new Yac();
+
+// 先往缓存里填 250 个条目
+for ($i = 0; $i < 250; $i++) {
+    $yac->set("key$i", $i);
+}
 
 $page_size = 100;
 $page_num  = 2;
@@ -241,9 +226,7 @@ int(100)
 ]]>
    </screen>
    <simpara>
-    当缓存中的条目数少于请求页覆盖的范围时，
-    返回的条目数会少于请求数；
-    当 offset 指向最后一个已占用槽位之后时，返回空数组。
+    当缓存中的条目数少于请求页覆盖的范围时，返回的条目数会少于请求数；当 offset 指向最后一个已占用槽位之后时，返回空数组。
    </simpara>
   </example>
  </refsect1>

--- a/reference/yac/yac/get.xml
+++ b/reference/yac/yac/get.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: Laruence Status: ready -->
+<!-- EN-Revision: c05fbe7250c43b75034ac776ed78f4e67163e4d3 Maintainer: Laruence Status: ready -->
 
 <refentry xml:id="yac.get" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -12,7 +12,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier> <type>mixed</type><methodname>Yac::get</methodname>
-   <methodparam><type class="union"><type>string</type><type>array</type></type><parameter>keys</parameter></methodparam>
+   <methodparam><type class="union"><type>string</type><type>array</type></type><parameter>key</parameter></methodparam>
    <methodparam choice="opt"><type>mixed</type><parameter>default</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <simpara>
@@ -24,7 +24,7 @@
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
-    <term><parameter>keys</parameter></term>
+    <term><parameter>key</parameter></term>
     <listitem>
      <simpara>
       <type>string</type> 类型的键，或者由键组成的 <type>array</type>。
@@ -35,14 +35,12 @@
     <term><parameter>default</parameter></term>
     <listitem>
      <simpara>
-      当请求的键（或多个键）不在缓存中时返回的值，
-      自 yac 2.4.0 起可用。省略时，未命中返回 &false;。
+      当请求的键（或多个键）不在缓存中时返回的值，自 yac 2.4.0 起可用。省略时，未命中返回 &false;。
      </simpara>
      <note>
       <simpara>
        在 yac 2.4.0 之前，该参数位置是一个引用形式的
-       <literal>$cas</literal> 令牌，而不是默认值。
-       传递过或依赖该令牌的代码在升级到 2.4.0 时必须更新。
+       <literal>$cas</literal> 令牌，而不是默认值。传递过或依赖该令牌的代码在升级到 2.4.0 时必须更新。
       </simpara>
      </note>
     </listitem>
@@ -53,15 +51,10 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   对于 <type>string</type> 类型的键，命中时返回缓存的值，
-   否则返回 <parameter>default</parameter>（未指定默认值时返回 &false;）。
+   对于 <type>string</type> 类型的键，命中时返回缓存的值，否则返回 <parameter>default</parameter>（未指定默认值时返回 &false;）。
   </simpara>
   <simpara>
-   对于由键组成的 <type>array</type>，返回一个数组，
-   其中包含所有命中的值，以各自的键为索引。
-   自 yac 2.4.0 起，不在缓存中的键会被直接忽略
-   （若指定了 <parameter>default</parameter>，则用默认值填充）；
-   在 2.4.0 之前，每个缺失的键都会插入一个 &false; 占位值。
+   对于由键组成的 <type>array</type>，返回一个数组，其中包含所有命中的值，以各自的键为索引。自 yac 2.4.0 起，不在缓存中的键会被直接忽略（若指定了 <parameter>default</parameter>，则用默认值填充）；在 2.4.0 之前，每个缺失的键都会插入一个 &false; 占位值。
   </simpara>
  </refsect1>
 
@@ -78,6 +71,16 @@ $yac = new Yac();
 $yac->set("foo", "bar");
 var_dump($yac->get("foo"));                 // string(3) "bar"
 var_dump($yac->get("missing"));             // bool(false)：未命中
+?>
+]]>
+   </programlisting>
+  </example>
+  <example>
+   <title>区分存进去的 false 和未命中</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$yac = new Yac();
 
 // 没有默认值时，未命中和存了 false 无法区分；
 // 哨兵默认值（自 yac 2.4.0 起可用）可以区分二者
@@ -86,9 +89,21 @@ var_dump($yac->get("flag"));                // bool(false)：存的就是这个�
 var_dump($yac->get("missing", false));      // bool(false)：未命中，形态相同
 var_dump($yac->get("flag", "__NONE__"));    // bool(false)：存的就是这个值
 var_dump($yac->get("missing", "__NONE__")); // string(8) "__NONE__"：未命中
+?>
+]]>
+   </programlisting>
+  </example>
+  <example>
+   <title>一次获取多个键</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$yac = new Yac();
+
+$yac->set("foo", "bar");
+$yac->set("foo2", "bar2");
 
 // 传入键数组时，结果中只包含命中的键
-$yac->set("foo2", "bar2");
 var_dump($yac->get(array("foo", "foo2", "missing")));
 // array(2) { ["foo"]=> string(3) "bar" ["foo2"]=> string(4) "bar2" }
 ?>

--- a/reference/yac/yac/info.xml
+++ b/reference/yac/yac/info.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: Laruence Status: ready -->
+<!-- EN-Revision: c05fbe7250c43b75034ac776ed78f4e67163e4d3 Maintainer: Laruence Status: ready -->
 
 <refentry xml:id="yac.info" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -130,25 +130,24 @@ print_r($yac->info());
 <![CDATA[
 Array
 (
-    [memory_size] => 46137344
-    [slots_memory_size] => 4194304
-    [values_memory_size] => 41943040
+    [memory_size] => 75497472
+    [slots_memory_size] => 8388608
+    [values_memory_size] => 67108864
     [segment_size] => 4194304
-    [segment_num] => 10
+    [segment_num] => 16
     [miss] => 0
     [hits] => 0
     [fails] => 0
     [kicks] => 0
     [recycles] => 0
     [start_time] => 1725955200
-    [slots_size] => 32768
+    [slots_size] => 65536
     [slots_used] => 1
 )
 ]]>
    </screen>
    <simpara>
-    命中率可以按 <literal>hits / (hits + miss)</literal> 计算；
-    持续增长的 <literal>kicks</literal> 或 <literal>fails</literal>
+    命中率可以按 <literal>hits / (hits + miss)</literal> 计算；持续增长的 <literal>kicks</literal> 或 <literal>fails</literal>
     计数器表明缓存正处于内存压力之下。
    </simpara>
   </example>

--- a/reference/yac/yac/set.xml
+++ b/reference/yac/yac/set.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: Laruence Status: ready -->
+<!-- EN-Revision: c05fbe7250c43b75034ac776ed78f4e67163e4d3 Maintainer: Laruence Status: ready -->
 
 <refentry xml:id="yac.set" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -12,7 +12,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier> <type>bool</type><methodname>Yac::set</methodname>
-   <methodparam><type class="union"><type>string</type><type>array</type></type><parameter>keys</parameter></methodparam>
+   <methodparam><type class="union"><type>string</type><type>array</type></type><parameter>key</parameter></methodparam>
    <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>ttl</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
@@ -22,8 +22,7 @@
    <methodparam choice="opt"><type>int</type><parameter>ttl</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <simpara>
-   向缓存中存储一个值。如果键已存在，
-   则覆盖已有条目，无论其是否已过期。
+   向缓存中存储一个值。如果键已存在，则覆盖已有条目，无论其是否已过期。
   </simpara>
  </refsect1>
 
@@ -31,7 +30,7 @@
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
-    <term><parameter>keys</parameter></term>
+    <term><parameter>key</parameter></term>
     <listitem>
      <simpara>
       <type>string</type> 类型的键，或者一个由
@@ -44,9 +43,7 @@
     <term><parameter>value</parameter></term>
     <listitem>
      <simpara>
-      要存储的值。除 <type>resource</type> 外的所有 PHP 类型都可以存储。
-      仅在单键形式下使用；当 <parameter>keys</parameter> 是数组时，
-      该参数位置实际上是可选的 <parameter>ttl</parameter>。
+      要存储的值。除 <type>resource</type> 外的所有 PHP 类型都可以存储。仅在单键形式下使用；当 <parameter>key</parameter> 是数组时，该参数位置实际上是可选的 <parameter>ttl</parameter>。
      </simpara>
     </listitem>
    </varlistentry>
@@ -79,11 +76,31 @@ $yac = new Yac();
 
 $yac->set("foo", "bar");                    // 存储单个值
 $yac->set("foo", "baz");                    // 覆盖已有条目
+?>
+]]>
+   </programlisting>
+  </example>
+  <example>
+   <title>存储带 TTL 的条目</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$yac = new Yac();
 
 // ttl 以秒为单位：该条目 5 秒后过期
 $yac->set("short-lived", "value", 5);
 sleep(6);
 var_dump($yac->get("short-lived"));        // bool(false)：已过期
+?>
+]]>
+   </programlisting>
+  </example>
+  <example>
+   <title>一次存储多个条目</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$yac = new Yac();
 
 // 一次调用存储多个键值对
 $yac->set(array("a" => 1, "b" => 2));


### PR DESCRIPTION
## 概述

跟翻 doc-en [`c05fbe72`](https://github.com/php/doc-en/commit/c05fbe7250c43b75034ac776ed78f4e67163e4d3)（*ext/yac: Add a Memory Management chapter and improve the examples*，PR php/doc-en#5822）。

## 改动

- **新增 `reference/yac/memory.xml`**（内存管理章节）：键池 / 值池两套独立共享内存的布局、槽位驱逐与回收语义、容量规划与 `Yac::info` 计数器观察指标
- **book.xml**：引入 `&reference.yac.memory;`，引言补基准测试链接与嵌入值整数范围修订（60 有符号位）
- **constants.xml**：补全 `YAC_VERSION` / `YAC_MAX_VALUE_RAW_LEN` / `YAC_MAX_RAW_COMPRESSED_LEN` 的空描述，修正序列化器常量说明
- **ini.xml**：更新 `compress_threshold`（默认 `4K`）与 `keys_memory_size`（默认 `8M`）默认值，重写两项内存说明并互链内存管理章节
- **add/set/get/delete/dump/info**：参数名 `keys`→`key` 对齐 arginfo，示例按参数形式拆分为独立可运行片段，修正 `hits` 重置语义与 `info` 输出数字

## 中文排版

中文 prose 收成连续单行，消除跨行被 phd 渲染折叠成的汉字间空格（一并修正 `dump.xml` 等存量）。

## 校验

- EN-Revision 指向 squash-merge 后的 doc-en master hash（`c05fbe72`），10 个文件本地复现 `check-en-revision` 全通过
- `check-structure.php` 骨架镜像：`divergent=0`
- `section-order.php`：0 issues；`extensions.xml.php --check`：通过
- configure + phd 本地渲染：交叉链接全部解析，渲染后中文间空格 0